### PR TITLE
Sync database with Recurse Center API

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,9 @@
 export CLIENT_ID=your_client_id
 export CLIENT_SECRET=your_client_secret
 
+# Personal access token - required for RC API sync
+export ACCESS_TOKEN=your_personal_access_token
+
 # Database configuration
 # see also:
 # - https://jdbc.postgresql.org/documentation/head/connect.html

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,13 +8,15 @@
     </option>
   </component>
   <component name="EntryPointsManager">
-    <list size="3">
+    <list size="4">
       <item index="0" class="java.lang.String" itemvalue="com.fasterxml.jackson.annotation.JsonProperty" />
       <item index="1" class="java.lang.String" itemvalue="org.springframework.context.annotation.Configuration" />
-      <item index="2" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.RequestMapping" />
+      <item index="2" class="java.lang.String" itemvalue="org.springframework.stereotype.Component" />
+      <item index="3" class="java.lang.String" itemvalue="org.springframework.web.bind.annotation.RequestMapping" />
     </list>
     <writeAnnotations>
       <writeAnnotation name="org.springframework.beans.factory.annotation.Autowired" />
+      <writeAnnotation name="org.springframework.beans.factory.annotation.Value" />
     </writeAnnotations>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   global:
     - CLIENT_ID=_
     - CLIENT_SECRET=_
+    - ACCESS_TOKEN=_
     - JDBC_DATABASE_URL=jdbc:postgresql:portfolio
     - JDBC_DATABASE_USERNAME=postgres
     - JDBC_DATABASE_PASSWORD=

--- a/README.markdown
+++ b/README.markdown
@@ -63,11 +63,16 @@ the following information.
 
 To run the web app locally,
 you will need to configure a
-[Recurse Center OAuth application](https://www.recurse.com/settings/apps).
+both an OAuth application
+and a personal access token
+in your
+[Recurse Center app settings](https://www.recurse.com/settings/apps).
 Create an app with the redirect URI to
 `http://127.0.0.1:8080/login/oauth2/code/recurse`,
 then take the client ID and client secret
 and set the environment variables `CLIENT_ID` and `CLIENT_SECRET`.
+Create a personal access token
+and set the environment variable `ACCESS_TOKEN`.
 
 The app requires a
 [PostgreSQL](https://www.postgresql.org/)
@@ -80,12 +85,23 @@ and then
 Put the database URL and credentials in the `JDBC_DATABASE` variables
 in your `.env` file.
 
-Then, execute the `bootRun` task:
+Populate the database
+by running the API sync:
+
+```
+$ source .env
+$ ./gradlew bootRun --args="apiSync"
+```
+
+Then, execute the `bootRun` task
+to start the web server:
 
 ```
 $ source .env
 $ ./gradlew bootRun
 ```
+
+The server should now be accessible at http://127.0.0.1:8080/.
 
 <a href='https://www.recurse.com' title='Made with love at the Recurse Center'><img src='https://cloud.githubusercontent.com/assets/2883345/11325206/336ea5f4-9150-11e5-9e90-d86ad31993d8.png' height='20px'/></a>
 ![Licensed under the AGPL, version 3](https://img.shields.io/badge/license-AGPL3-blue.svg)

--- a/src/main/java/com/recurse/portfolio/Application.java
+++ b/src/main/java/com/recurse/portfolio/Application.java
@@ -12,6 +12,7 @@ public class Application {
     private static final List<String> REQUIRED_ENVIRONMENT_VARIABLES = List.of(
         "CLIENT_ID",
         "CLIENT_SECRET",
+        "ACCESS_TOKEN",
         "JDBC_DATABASE_URL",
         "JDBC_DATABASE_USERNAME",
         "JDBC_DATABASE_PASSWORD"

--- a/src/main/java/com/recurse/portfolio/RecurseOAuthSuccessHandler.java
+++ b/src/main/java/com/recurse/portfolio/RecurseOAuthSuccessHandler.java
@@ -1,6 +1,9 @@
 package com.recurse.portfolio;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recurse.portfolio.data.RecurseProfile;
+import com.recurse.portfolio.data.User;
+import com.recurse.portfolio.data.UserRepository;
 import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
@@ -37,9 +40,13 @@ public class RecurseOAuthSuccessHandler implements AuthenticationSuccessHandler 
             log.info("Profile: " + profile.toString());
 
             User user = repository
-                .findByRecurseProfileId(profile.userId)
+                .findByRecurseProfileId(profile.getUserId())
                 .orElseGet(() ->
-                    repository.save(new User(0, profile.userId, profile.name))
+                    repository.save(new User(
+                        0,
+                        profile.getUserId(),
+                        profile.getName())
+                    )
                 );
             log.info("User: " + user.toString());
         }

--- a/src/main/java/com/recurse/portfolio/data/ApiSync.java
+++ b/src/main/java/com/recurse/portfolio/data/ApiSync.java
@@ -1,0 +1,206 @@
+package com.recurse.portfolio.data;
+
+import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@Log
+public class ApiSync implements ApplicationRunner {
+    private static final String PROFILES_URL =
+        "https://www.recurse.com/api/v1/profiles?limit={limit}&offset={offset}";
+    private static final int PROFILES_PAGE_SIZE = 50;
+
+    @Autowired
+    ConfigurableApplicationContext application;
+
+    @Autowired
+    DataSource dataSource;
+
+    @Value("${ACCESS_TOKEN}")
+    private String accessToken;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        if (!args.getNonOptionArgs().contains("apiSync")) {
+            return;
+        }
+
+        log.info("Syncing database with Recurse Center API...");
+        Connection connection = dataSource.getConnection();
+        connection.setAutoCommit(false);
+        final List<RecurseProfile> profiles = fetchProfiles();
+        log.info(String.format("Fetched %d profiles", profiles.size()));
+
+        updateProfiles(profiles, connection);
+        connection.commit();
+        log.info("Sync complete.");
+        application.close();
+    }
+
+    private List<RecurseProfile> fetchProfiles() {
+        RestTemplate client = new RestTemplate();
+        HttpEntity<String> entity = getAuthHeader();
+        final ParameterizedTypeReference<List<RecurseProfile>> responseType
+            = new ParameterizedTypeReference<>() {
+        };
+        List<RecurseProfile> profiles = new ArrayList<>();
+        int offset = 0;
+        List<RecurseProfile> page;
+
+        do {
+            page = Optional.ofNullable(
+                client.exchange(
+                    PROFILES_URL,
+                    HttpMethod.GET,
+                    entity,
+                    responseType,
+                    PROFILES_PAGE_SIZE,
+                    offset
+                ).getBody()
+            ).orElse(Collections.emptyList());
+            profiles.addAll(page);
+            offset += PROFILES_PAGE_SIZE;
+        } while (!page.isEmpty());
+
+        return profiles;
+    }
+
+    private void updateProfiles(
+        List<RecurseProfile> profiles,
+        Connection connection
+    ) throws SQLException {
+        PreparedStatement upsertProfile = connection.prepareStatement(
+            "INSERT INTO recurse_profiles (" +
+                "  recurse_profile_id," +
+                "  name," +
+                "  email," +
+                "  github," +
+                "  twitter," +
+                "  image_url," +
+                "  directory_url" +
+                ") " +
+                "VALUES(?, ?, ?, ?, ?, ?, ?) " +
+                "ON CONFLICT (recurse_profile_id) " +
+                "DO UPDATE SET" +
+                "  name = EXCLUDED.name," +
+                "  email = EXCLUDED.email," +
+                "  github = EXCLUDED.github," +
+                "  twitter = EXCLUDED.twitter," +
+                "  image_url = EXCLUDED.image_url," +
+                "  directory_url = EXCLUDED.directory_url"
+        );
+        for (RecurseProfile profile : profiles) {
+            upsertProfile.setInt(1, profile.getUserId());
+            upsertProfile.setString(2, profile.getName());
+            upsertProfile.setString(3, profile.getEmail());
+            upsertProfile.setString(4, profile.getGithub());
+            upsertProfile.setString(5, profile.getTwitter());
+            upsertProfile.setString(6, profile.getImageUrl());
+            upsertProfile.setString(7, profile.getDirectoryUrl());
+            upsertProfile.executeUpdate();
+            updateStints(profile.getUserId(), profile.getStints(), connection);
+        }
+    }
+
+    private void updateStints(
+        int profileId,
+        List<Stint> stints,
+        Connection connection
+    ) throws SQLException {
+        PreparedStatement upsertStint = connection.prepareStatement(
+            "INSERT INTO stints (" +
+                "  recurse_profile_id," +
+                "  batch_id," +
+                "  start_date," +
+                "  end_date," +
+                "  for_half_batch," +
+                "  title," +
+                "  stint_type" +
+                ") " +
+                "VALUES(?, ?, ?, ?, ?, ?, ?) " +
+                "ON CONFLICT (recurse_profile_id, start_date) " +
+                "DO UPDATE SET" +
+                "  batch_id = EXCLUDED.batch_id," +
+                "  end_date = EXCLUDED.end_date," +
+                "  for_half_batch = EXCLUDED.for_half_batch," +
+                "  title = EXCLUDED.title," +
+                "  stint_type = EXCLUDED.stint_type"
+        );
+        for (Stint stint : stints) {
+            upsertStint.setInt(1, profileId);
+            if (stint.getBatch() == null) {
+                upsertStint.setNull(2, Types.INTEGER);
+            } else {
+                updateBatch(stint.getBatch(), connection);
+                upsertStint.setInt(2, stint.getBatch().getBatchId());
+            }
+            upsertStint.setDate(3, Date.valueOf(stint.getStartDate()));
+            upsertStint.setDate(4, sqlDate(stint.getEndDate()));
+            upsertStint.setBoolean(5, stint.isForHalfBatch());
+            upsertStint.setString(6, stint.getTitle());
+            upsertStint.setString(7, stint.getType());
+            upsertStint.executeUpdate();
+        }
+    }
+
+    private void updateBatch(
+        Batch batch,
+        Connection connection
+    ) throws SQLException {
+        PreparedStatement upsertBatch = connection.prepareStatement(
+            "INSERT INTO batches (" +
+                "  batch_id," +
+                "  name," +
+                "  name_alt," +
+                "  name_short" +
+                ") " +
+                "VALUES(?, ?, ?, ?) " +
+                "ON CONFLICT (batch_id) " +
+                "DO UPDATE SET" +
+                "  name = EXCLUDED.name," +
+                "  name_alt = EXCLUDED.name_alt," +
+                "  name_short = EXCLUDED.name_short"
+        );
+        upsertBatch.setInt(1, batch.getBatchId());
+        upsertBatch.setString(2, batch.getName());
+        upsertBatch.setString(3, batch.getAltName());
+        upsertBatch.setString(4, batch.getShortName());
+        upsertBatch.executeUpdate();
+    }
+
+    private Date sqlDate(LocalDate date) {
+        return Optional.ofNullable(date)
+            .map(Date::valueOf)
+            .orElse(null);
+    }
+
+    private HttpEntity<String> getAuthHeader() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBearerAuth(accessToken);
+        httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
+        return new HttpEntity<>("parameters", httpHeaders);
+    }
+}

--- a/src/main/java/com/recurse/portfolio/data/Batch.java
+++ b/src/main/java/com/recurse/portfolio/data/Batch.java
@@ -1,0 +1,19 @@
+package com.recurse.portfolio.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Batch {
+    @JsonProperty("id")
+    int batchId;
+
+    String name;
+
+    String altName;
+
+    String shortName;
+}

--- a/src/main/java/com/recurse/portfolio/data/RecurseProfile.java
+++ b/src/main/java/com/recurse/portfolio/data/RecurseProfile.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NonNull;
 
+import java.util.List;
+
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RecurseProfile {
@@ -22,6 +24,8 @@ public class RecurseProfile {
     @NonNull String imageUrl;
 
     @NonNull String directoryUrl;
+
+    @NonNull List<Stint> stints;
 
     public RecurseProfile() {}
 

--- a/src/main/java/com/recurse/portfolio/data/RecurseProfile.java
+++ b/src/main/java/com/recurse/portfolio/data/RecurseProfile.java
@@ -1,4 +1,4 @@
-package com.recurse.portfolio;
+package com.recurse.portfolio.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/recurse/portfolio/data/Stint.java
+++ b/src/main/java/com/recurse/portfolio/data/Stint.java
@@ -1,0 +1,33 @@
+package com.recurse.portfolio.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@JsonIgnoreProperties("in_progress")
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Stint {
+    @JsonProperty("id")
+    int stintId;
+
+    Batch batch;
+
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    LocalDate startDate;
+
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    LocalDate endDate;
+
+    boolean forHalfBatch;
+
+    String title;
+
+    String type;
+}

--- a/src/main/java/com/recurse/portfolio/data/User.java
+++ b/src/main/java/com/recurse/portfolio/data/User.java
@@ -1,4 +1,4 @@
-package com.recurse.portfolio;
+package com.recurse.portfolio.data;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/recurse/portfolio/data/UserRepository.java
+++ b/src/main/java/com/recurse/portfolio/data/UserRepository.java
@@ -1,11 +1,11 @@
-package com.recurse.portfolio;
+package com.recurse.portfolio.data;
 
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-interface UserRepository
+public interface UserRepository
     extends CrudRepository<User, Integer>
 {
     @Query("select * from users where recurse_profile_id = :recurseProfileId")

--- a/src/main/resources/db/migration/V2__Create_recurse_tables.sql
+++ b/src/main/resources/db/migration/V2__Create_recurse_tables.sql
@@ -1,0 +1,33 @@
+CREATE TABLE batches (
+  batch_id INTEGER PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL,
+  name_alt TEXT,
+  name_short TEXT
+);
+
+CREATE TABLE recurse_profiles (
+  recurse_profile_id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  github TEXT,
+  twitter TEXT,
+  image_url TEXT NOT NULL,
+  directory_url TEXT NOT NULL
+);
+
+CREATE TABLE stints (
+  recurse_profile_id INTEGER NOT NULL
+    REFERENCES recurse_profiles(recurse_profile_id),
+  batch_id INTEGER
+    REFERENCES batches(batch_id),
+  start_date DATE NOT NULL,
+  end_date DATE,
+  for_half_batch BOOLEAN NOT NULL,
+  title TEXT,
+  stint_type TEXT NOT NULL,
+  PRIMARY KEY (recurse_profile_id, start_date)
+);
+
+ALTER TABLE users
+ADD FOREIGN KEY (recurse_profile_id)
+REFERENCES recurse_profiles(recurse_profile_id);


### PR DESCRIPTION
Add a command line task to fetch the directory from the [Recurse Center API :lock:](https://github.com/recursecenter/wiki/wiki/Recurse-Center-API) and store it locally. Once this project has been deployed somewhere, this task can be run periodically to keep the database up-to-date.

Spring Data JDBC doesn't like to have application-defined entity IDs, and all of the data from the API has its own IDs, so drop down to regular JDBC to do insert-or-updates. I tried doing this with `@Query` methods on various `Repository`-extending interfaces, but it ended up being more code (albeit possibly easier to read) that was much slower.

This is very similar to the [approach](https://github.com/jasonaowen/recurse-faces/commit/eb62662b8c42578249de912f34fc984e0c3c1715) I took in [recurse-faces](https://github.com/jasonaowen/recurse-faces).