### PR TITLE
Log test names and status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
   id 'org.flywaydb.flyway' version '5.2.4'
   id 'io.spring.dependency-management' version '1.0.7.RELEASE'
   id 'io.freefair.lombok' version '3.2.0'
+  id 'com.adarshr.test-logger' version '1.6.0'
 }
 
 repositories {


### PR DESCRIPTION
Use the [test-logger Gradle plugin](https://nvd.nist.gov/vuln/detail/CVE-2019-11065) to show some details about the test suite, so as to make CI a bit more useful - and in particular, make it clear that the tests are both running and passing.

Example output, showing the `HomeControllerTest#index` method passing:

```
$ ./gradlew test
> Task :test
2019-04-22 13:04:03.718  INFO 8627 --- [       Thread-6] o.s.s.concurrent.ThreadPoolTaskExecutor  : Shutting down ExecutorService 'applicationTaskExecutor'
2019-04-22 13:04:03.720  INFO 8627 --- [       Thread-6] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...

2019-04-22 13:04:03.774  INFO 8627 --- [       Thread-6] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
com.recurse.portfolio.HomeControllerTest

  Test index PASSED

SUCCESS: Executed 1 tests in 8.1s


BUILD SUCCESSFUL in 23s
5 actionable tasks: 5 executed
```

(The relevant new line is

```
  Test index PASSED
```
)