### PR TITLE
Extract common HTML to a Thymeleaf layout frament

### DIFF
--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en" data-th-fragment="layout(title, content)">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+  <title data-th-replace="${title}">Recurse Center Community Portfolio</title>
+</head>
+<body>
+  <header>
+    <h1>Recurse Center Community Portfolio</h1>
+    <div data-th-if="${currentUser}">Hello,
+      <span data-th-text="${currentUser.internalName}">currently logged in user</span>
+    </div>
+    <div data-th-unless="${currentUser}">
+      <a href="?login">Log In</a>
+    </div>
+  </header>
+  <main data-th-replace="${content}">
+    <p>Layout content</p>
+  </main>
+  <footer data-th-fragment="footer">
+    Made with ❤️ with and for the
+    <a href="https://www.recurse.com/scout/click?t=ac9449867495df95991da39e95823b65">
+      Recurse Center</a>
+    community.
+    (<a href="https://github.com/jasonaowen/recurse-community-portfolio">Source</a>)
+  </footer>
+</body>
+</html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,28 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport"
-        content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <title>Recurse Center Community Portfolio</title>
 </head>
 <body>
-  <header>
-    <h1>Recurse Center Community Portfolio</h1>
-    <div data-th-if="${currentUser}">Hello,
-      <span data-th-text="${currentUser.internalName}">currently logged in user</span>
-    </div>
-    <div data-th-unless="${currentUser}">
-      <a href="?login">Log In</a>
-    </div>
-  </header>
+<main>
   <p>Content will go here.</p>
-  <footer>
-    Made with ❤️ with and for the
-    <a href="https://www.recurse.com/scout/click?t=ac9449867495df95991da39e95823b65">
-      Recurse Center</a>
-    community.
-    (<a href="https://github.com/jasonaowen/recurse-community-portfolio">Source</a>)
-  </footer>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -1,17 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport"
-        content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <title>Edit Profile - Portfolio</title>
 </head>
 <body>
-<header>
-  <h1>Recurse Center Community Portfolio</h1>
-</header>
-
-<div>
+<main>
   <form
     data-th-object="${user}"
     data-th-action="@{/user/{id}/edit(id=${user.userId})}"
@@ -82,15 +75,6 @@
       <input type="submit"/>
     </div>
   </form>
-</div>
-<footer>
-  Made with ❤️ with and for the
-  <a
-    href="https://www.recurse.com/scout/click?t=ac9449867495df95991da39e95823b65">
-    Recurse Center</a>
-  community.
-  (<a
-  href="https://github.com/jasonaowen/recurse-community-portfolio">Source</a>)
-</footer>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/users/peer.html
+++ b/src/main/resources/templates/users/peer.html
@@ -1,18 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport"
-        content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <title data-th-text="${user.internalName} + ' - Portfolio'">
     Peer's User Page - Portfolio
   </title>
 </head>
 <body>
-<header>
-  <h1>Recurse Center Community Portfolio</h1>
-</header>
-<div>
+<main>
   <div>
     Name: <span data-th-text="${user.internalName}">internal name</span>
   </div>
@@ -35,13 +29,6 @@
   <div>
     Profile visibility: <span data-th-text="${user.profileVisibility}">visibility</span>
   </div>
-</div>
-<footer>
-  Made with ❤️ with and for the
-  <a href="https://www.recurse.com/scout/click?t=ac9449867495df95991da39e95823b65">
-    Recurse Center</a>
-  community.
-  (<a href="https://github.com/jasonaowen/recurse-community-portfolio">Source</a>)
-</footer>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/users/public.html
+++ b/src/main/resources/templates/users/public.html
@@ -1,18 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport"
-        content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <title data-th-text="${user.internalName} + ' - Portfolio'">
     Public User Page - Portfolio
   </title>
 </head>
 <body>
-<header>
-  <h1>Recurse Center Community Portfolio</h1>
-</header>
-<div>
+<main>
   <div>
     Name: <span data-th-text="${user.publicName}">public name</span>
   </div>
@@ -24,13 +18,6 @@
     Bio:
     <div data-th-text="${user.publicBio}">public bio</div>
   </div>
-</div>
-<footer>
-  Made with ❤️ with and for the
-  <a href="https://www.recurse.com/scout/click?t=ac9449867495df95991da39e95823b65">
-    Recurse Center</a>
-  community.
-  (<a href="https://github.com/jasonaowen/recurse-community-portfolio">Source</a>)
-</footer>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/users/self.html
+++ b/src/main/resources/templates/users/self.html
@@ -1,18 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport"
-        content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <title data-th-text="${user.internalName} + ' - Portfolio'">
     My User Page - Portfolio
   </title>
 </head>
 <body>
-<header>
-  <h1>Recurse Center Community Portfolio</h1>
-</header>
-<div>
+<main>
   <div>
     My name (public): <span data-th-text="${user.publicName}">public name</span>
   </div>
@@ -41,13 +35,6 @@
   <div>
     <a data-th-href="@{/user/{id}/edit(id=${user.userId})}">Edit</a>
   </div>
-</div>
-<footer>
-  Made with ❤️ with and for the
-  <a href="https://www.recurse.com/scout/click?t=ac9449867495df95991da39e95823b65">
-    Recurse Center</a>
-  community.
-  (<a href="https://github.com/jasonaowen/recurse-community-portfolio">Source</a>)
-</footer>
+</main>
 </body>
 </html>


### PR DESCRIPTION
Use [Thymeleaf's layout fragment support](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html#layout-inheritance) to create a base layout page and reuse it in each of the other templates, reducing them to only the (valid!) HTML that is unique to that page.

Issue #10 Improve appearance of pages