### PR TITLE
Fix user creation by properly (un)setting user ID

### DIFF
--- a/src/main/java/com/recurse/portfolio/security/PortfolioOAuth2UserService.java
+++ b/src/main/java/com/recurse/portfolio/security/PortfolioOAuth2UserService.java
@@ -37,7 +37,7 @@ public class PortfolioOAuth2UserService
 
     private User createUserFromProfile(RecurseProfile profile) {
         return userRepository.save(User.builder()
-            .userId(0)
+            .userId(null)
             .recurseProfileId(profile.getUserId())
             .profileVisibility(Visibility.PRIVATE)
             .internalName(profile.getName())


### PR DESCRIPTION
In commit 0d4efa03549f9b112f1277502424876bf2238c27, I changed the `User` model from using an `int` to an `Integer` for the `userId`. Spring Data JDBC looks at the `@Id`-annotated field to determine if it should update or create, and while `int(0)` indicates a new entity, `Integer(0)` indicates an existing entity.

Set the `userId` to `null` to create a new user.