### PR TITLE
Link to the current user's profile in the header

### DIFF
--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -18,8 +18,11 @@
     </h1>
     <div class="header-element header-user" data-th-if="${currentUser}">
       Hello,
-      <span data-th-text="${currentUser.internalName}">
-        currently logged in user</span>!
+      <a
+        href="users/self.html"
+        data-th-href="@{/user/{id}(id=${currentUser.userId})}"
+        data-th-text="${currentUser.internalName}">
+        currently logged in user</a>!
     </div>
     <div class="header-element header-new-project" data-th-if="${currentUser}">
       <a href="/project/new">Create a new project</a>


### PR DESCRIPTION
Update the logged-in-user greeting to be a link to their profile, which might not be otherwise discoverable.

Before:
![before-profile-link](https://user-images.githubusercontent.com/1494855/56751689-aaaeb180-6754-11e9-8f51-cfddaf7a9359.png)

After:
![after-profile-link](https://user-images.githubusercontent.com/1494855/56751698-ae423880-6754-11e9-852d-0e538599d2a6.png)
