### PR TITLE
Add Markdown parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,10 @@ sourceCompatibility = 11
 targetCompatibility = 11
 
 dependencies {
+  compile('com.vladsch.flexmark:flexmark-all:0.42.6')
   compile('com.zaxxer:HikariCP:3.3.1')
   compile('org.flywaydb:flyway-core:5.2.4')
+  compile('org.jsoup:jsoup:1.11.3')
   compile('org.postgresql:postgresql:42.2.5')
   compile('org.springframework.boot:spring-boot-starter-data-jdbc')
   compile('org.springframework.boot:spring-boot-starter-oauth2-client')

--- a/src/main/java/com/recurse/portfolio/web/MarkdownHelper.java
+++ b/src/main/java/com/recurse/portfolio/web/MarkdownHelper.java
@@ -1,0 +1,46 @@
+package com.recurse.portfolio.web;
+
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.emoji.EmojiExtension;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughSubscriptExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.superscript.SuperscriptExtension;
+import com.vladsch.flexmark.util.options.MutableDataHolder;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
+
+import java.util.List;
+
+import static com.vladsch.flexmark.ext.emoji.EmojiImageType.UNICODE_ONLY;
+
+class MarkdownHelper {
+    private static final MutableDataHolder OPTIONS = new MutableDataSet()
+        .set(Parser.EXTENSIONS, List.of(
+            AutolinkExtension.create(),
+            EmojiExtension.create(),
+            StrikethroughSubscriptExtension.create(),
+            SuperscriptExtension.create(),
+            TablesExtension.create(),
+            TaskListExtension.create()
+        ))
+        .set(EmojiExtension.USE_IMAGE_TYPE, UNICODE_ONLY);
+
+    static String renderMarkdownToHtml(String input) {
+        Parser markdownParser = Parser.builder(OPTIONS).build();
+        HtmlRenderer htmlRenderer = HtmlRenderer.builder(OPTIONS).build();
+
+        String renderedMarkdown = htmlRenderer.render(
+            markdownParser.parse(input)
+        );
+
+        return Jsoup.clean(
+            renderedMarkdown,
+            Whitelist.relaxed()
+                .addTags("del", "hr")
+        );
+    }
+}

--- a/src/main/java/com/recurse/portfolio/web/ProjectController.java
+++ b/src/main/java/com/recurse/portfolio/web/ProjectController.java
@@ -18,6 +18,8 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.Set;
 
+import static com.recurse.portfolio.web.MarkdownHelper.renderMarkdownToHtml;
+
 @Controller
 public class ProjectController {
     @Autowired
@@ -76,6 +78,16 @@ public class ProjectController {
         ModelAndView mv = new ModelAndView(
             policy.evaluate(authors, currentUser)
         );
+
+        project.setPublicDescription(renderMarkdownToHtml(
+            project.getPublicDescription()
+        ));
+        project.setInternalDescription(renderMarkdownToHtml(
+            project.getInternalDescription()
+        ));
+        project.setPrivateDescription(renderMarkdownToHtml(
+            project.getPrivateDescription()
+        ));
 
         mv.addObject("project", project);
         mv.addObject("authors", authors);

--- a/src/main/java/com/recurse/portfolio/web/UserController.java
+++ b/src/main/java/com/recurse/portfolio/web/UserController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
+import static com.recurse.portfolio.web.MarkdownHelper.renderMarkdownToHtml;
+
 @Controller
 @Log
 public class UserController {
@@ -39,6 +41,13 @@ public class UserController {
         ModelAndView mv = new ModelAndView(
             policy.evaluate(requestedUser, currentUser)
         );
+
+        requestedUser.setPublicBio(renderMarkdownToHtml(
+            requestedUser.getPublicBio()
+        ));
+        requestedUser.setInternalBio(renderMarkdownToHtml(
+            requestedUser.getInternalBio()
+        ));
 
         mv.addObject("user", requestedUser);
         return mv;

--- a/src/main/resources/templates/projects/author.html
+++ b/src/main/resources/templates/projects/author.html
@@ -50,18 +50,18 @@
   <section class="project-descriptions">
     <section class="project-description">
       <h2 class="project-description-visibility">Private</h2>
-      <p data-th-text="${project.privateDescription}">
+      <div data-th-utext="${project.privateDescription}">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
         justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
         Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
         quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
         non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
         Cras ultrices rutrum tristique.
-      </p>
+      </div>
     </section>
     <section class="project-description">
       <h2 class="project-description-visibility">Internal</h2>
-      <p data-th-text="${project.internalDescription}">
+      <div data-th-utext="${project.internalDescription}">
         Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
         euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
         dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
@@ -69,11 +69,11 @@
         orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
         tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
         lacinia neque.
-      </p>
+      </div>
     </section>
     <section class="project-description">
       <h2 class="project-description-visibility">Public</h2>
-      <p data-th-text="${project.publicDescription}">
+      <div data-th-utext="${project.publicDescription}">
         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
         cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
         mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
@@ -87,7 +87,7 @@
         sem in, malesuada ornare tortor. Proin id fermentum justo, sed
         condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
         at egestas.
-      </p>
+      </div>
     </section>
   </section>
   <section class="project-settings">

--- a/src/main/resources/templates/projects/edit.html
+++ b/src/main/resources/templates/projects/edit.html
@@ -73,6 +73,9 @@ quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
 non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
 Cras ultrices rutrum tristique.
           </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </section>
         <section class="project-description">
           <h2 class="project-description-visibility">Internal</h2>
@@ -89,7 +92,10 @@ amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
 orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
 tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
 lacinia neque.
-        </textarea>
+          </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </section>
         <section class="project-description">
           <h2 class="project-description-visibility">Public</h2>
@@ -111,7 +117,10 @@ leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
 sem in, malesuada ornare tortor. Proin id fermentum justo, sed
 condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
 at egestas.
-        </textarea>
+          </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </section>
       </section>
       <section class="project-settings">

--- a/src/main/resources/templates/projects/peer.html
+++ b/src/main/resources/templates/projects/peer.html
@@ -50,7 +50,7 @@
   <section class="project-descriptions">
     <section class="project-description">
       <h2 class="project-description-visibility">Internal</h2>
-      <p data-th-text="${project.internalDescription}">
+      <div data-th-utext="${project.internalDescription}">
         Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
         euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
         dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
@@ -58,11 +58,11 @@
         orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
         tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
         lacinia neque.
-      </p>
+      </div>
     </section>
     <section class="project-description">
       <h2 class="project-description-visibility">Public</h2>
-      <p data-th-text="${project.publicDescription}">
+      <div data-th-utext="${project.publicDescription}">
         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
         cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
         mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
@@ -76,7 +76,7 @@
         sem in, malesuada ornare tortor. Proin id fermentum justo, sed
         condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
         at egestas.
-      </p>
+      </div>
     </section>
   </section>
 </main>

--- a/src/main/resources/templates/projects/public.html
+++ b/src/main/resources/templates/projects/public.html
@@ -49,7 +49,7 @@
   </section>
   <section class="project-descriptions">
     <section class="project-description">
-      <p data-th-text="${project.publicDescription}">
+      <div data-th-utext="${project.publicDescription}">
         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
         cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
         mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
@@ -63,7 +63,7 @@
         sem in, malesuada ornare tortor. Proin id fermentum justo, sed
         condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
         at egestas.
-      </p>
+      </div>
     </section>
   </section>
 </main>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -47,7 +47,10 @@ commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
 velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
 occaecat cupidatat non proident, sunt in culpa qui officia deserunt
 mollit anim id est laborum.
-        </textarea>
+          </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </label>
       </section>
       <section class="user-view">
@@ -88,7 +91,10 @@ ut lacus efficitur mollis a id nisl. Phasellus ullamcorper ultricies
 dolor. Maecenas condimentum magna sit amet venenatis sodales.
 Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
 pretium sit amet pulvinar non, mattis eu metus.
-        </textarea>
+          </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </label>
       </section>
     </section>

--- a/src/main/resources/templates/users/peer.html
+++ b/src/main/resources/templates/users/peer.html
@@ -20,7 +20,7 @@
     </div>
     <div class="user-bio">
       Bio:
-      <p data-th-text="${user.internalBio}">
+      <div data-th-utext="${user.internalBio}">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -28,7 +28,7 @@
         velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
         occaecat cupidatat non proident, sunt in culpa qui officia deserunt
         mollit anim id est laborum.
-      </p>
+      </div>
     </div>
   </section>
   <section class="user-view">
@@ -43,7 +43,7 @@
     </div>
     <div class="user-bio">
       Bio:
-      <p data-th-text="${user.publicBio}">
+      <div data-th-utext="${user.publicBio}">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat
         lobortis arcu vel feugiat. Nullam sagittis commodo turpis nec pretium.
         Nulla bibendum ligula posuere malesuada posuere. Curabitur ullamcorper
@@ -54,7 +54,7 @@
         dolor. Maecenas condimentum magna sit amet venenatis sodales.
         Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
         pretium sit amet pulvinar non, mattis eu metus.
-      </p>
+      </div>
     </div>
   </section>
 </main>

--- a/src/main/resources/templates/users/public.html
+++ b/src/main/resources/templates/users/public.html
@@ -19,7 +19,7 @@
     </div>
     <div class="user-bio">
       Bio:
-      <p data-th-text="${user.publicBio}">
+      <div data-th-utext="${user.publicBio}">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat
         lobortis arcu vel feugiat. Nullam sagittis commodo turpis nec pretium.
         Nulla bibendum ligula posuere malesuada posuere. Curabitur ullamcorper
@@ -30,7 +30,7 @@
         dolor. Maecenas condimentum magna sit amet venenatis sodales.
         Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
         pretium sit amet pulvinar non, mattis eu metus.
-      </p>
+      </div>
     </div>
   </section>
 </main>

--- a/src/main/resources/templates/users/self.html
+++ b/src/main/resources/templates/users/self.html
@@ -20,7 +20,7 @@
     </div>
     <div class="user-bio">
       Bio:
-      <p data-th-text="${user.internalBio}">
+      <div data-th-utext="${user.internalBio}">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -28,7 +28,7 @@
         velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
         occaecat cupidatat non proident, sunt in culpa qui officia deserunt
         mollit anim id est laborum.
-      </p>
+      </div>
     </div>
   </section>
   <section class="user-view">
@@ -43,7 +43,7 @@
     </div>
     <div class="user-bio">
       Bio:
-      <p data-th-text="${user.publicBio}">
+      <div data-th-utext="${user.publicBio}">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat
         lobortis arcu vel feugiat. Nullam sagittis commodo turpis nec pretium.
         Nulla bibendum ligula posuere malesuada posuere. Curabitur ullamcorper
@@ -54,7 +54,7 @@
         dolor. Maecenas condimentum magna sit amet venenatis sodales.
         Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
         pretium sit amet pulvinar non, mattis eu metus.
-      </p>
+      </div>
     </div>
   </section>
   <section class="user-settings">


### PR DESCRIPTION
Parse user bios and project descriptions as Markdown, using [flexmark-java](https://github.com/vsch/flexmark-java). [Clean](https://jsoup.org/cookbook/cleaning-html/whitelist-sanitizer) the rendered HTML with [jsoup](https://github.com/jhy/jsoup) to prevent XSS attacks.

Configure flexmark to enable several of its [extensions](https://github.com/vsch/flexmark-java/wiki/Extensions), because they're fun and why not. 😄

Use Thymeleaf's [unescaped text](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html#unescaped-text) attribute to properly display our rendered html.

It would be nice to have self-hosted help docs, including for all the configured extensions, but for now link to the CommonMark help docs for basic Markdown usage.

![markdown](https://user-images.githubusercontent.com/1494855/56751985-44765e80-6755-11e9-8f79-9fea4ede6b3c.png)

Resolves #23 Parse descriptions as markdown