### PR TITLE
Show projects on home and user pages

### DIFF
--- a/src/main/java/com/recurse/portfolio/data/Project.java
+++ b/src/main/java/com/recurse/portfolio/data/Project.java
@@ -4,8 +4,12 @@ import com.recurse.portfolio.security.Visibility;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Data
 @NoArgsConstructor
@@ -15,6 +19,9 @@ public class Project {
     Integer projectId;
 
     Visibility visibility;
+
+    @Transient
+    Set<User> authors = new HashSet<>();
 
     String name;
 

--- a/src/main/java/com/recurse/portfolio/data/ProjectAndAuthor.java
+++ b/src/main/java/com/recurse/portfolio/data/ProjectAndAuthor.java
@@ -1,0 +1,31 @@
+package com.recurse.portfolio.data;
+
+import lombok.Data;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Table("project_authors")
+public class ProjectAndAuthor {
+    @Column(value = "project_id", keyColumn = "project_id")
+    Project project;
+
+    @Column(value = "author_id", keyColumn = "user_id")
+    User author;
+
+    public static Collection<Project> collect(List<ProjectAndAuthor> list) {
+        Map<Integer, Project> projectsById = new HashMap<>();
+        for (ProjectAndAuthor pa : list) {
+            projectsById.putIfAbsent(pa.project.getProjectId(), pa.project);
+            projectsById.get(pa.project.getProjectId()).getAuthors().add(
+                pa.getAuthor()
+            );
+        }
+        return projectsById.values();
+    }
+}

--- a/src/main/java/com/recurse/portfolio/data/ProjectRepository.java
+++ b/src/main/java/com/recurse/portfolio/data/ProjectRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.Set;
 
 public interface ProjectRepository
@@ -22,4 +23,57 @@ public interface ProjectRepository
         "values (:projectId, :authorId) " +
         "on conflict(author_id, project_id) do nothing")
     void addProjectAuthor(int projectId, int authorId);
+
+    @Query("select" +
+        "  p.project_id as project_project_id," +
+        "  p.visibility as project_visibility," +
+        "  p.name as project_name," +
+        "  p.description_private as project_description_private," +
+        "  p.description_internal as project_description_internal," +
+        "  p.description_public as project_description_public," +
+        "  a.user_id as author_user_id," +
+        "  a.recurse_profile_id as author_recurse_profile_id," +
+        "  a.name_internal as author_name_internal," +
+        "  a.profile_visibility as author_profile_visibility," +
+        "  a.name_public as author_name_public," +
+        "  a.image_url_internal as author_image_url_internal," +
+        "  a.image_url_public as author_image_url_public," +
+        "  a.bio_internal as author_bio_internal," +
+        "  a.bio_public as author_bio_public " +
+        "from projects p" +
+        "  inner join project_authors pa" +
+        "    on p.project_id = pa.project_id" +
+        "  inner join users a" +
+        "    on pa.author_id = a.user_id " +
+        "where visibility = 'PUBLIC' " +
+        "order by p.project_id desc " +
+        "limit :limit")
+    List<ProjectAndAuthor> getPublicProjects(int limit);
+
+    @Query("select" +
+        "  p.project_id as project_project_id," +
+        "  p.visibility as project_visibility," +
+        "  p.name as project_name," +
+        "  p.description_private as project_description_private," +
+        "  p.description_internal as project_description_internal," +
+        "  p.description_public as project_description_public," +
+        "  a.user_id as author_user_id," +
+        "  a.recurse_profile_id as author_recurse_profile_id," +
+        "  a.name_internal as author_name_internal," +
+        "  a.profile_visibility as author_profile_visibility," +
+        "  a.name_public as author_name_public," +
+        "  a.image_url_internal as author_image_url_internal," +
+        "  a.image_url_public as author_image_url_public," +
+        "  a.bio_internal as author_bio_internal," +
+        "  a.bio_public as author_bio_public " +
+        "from projects p" +
+        "  inner join project_authors pa" +
+        "    on p.project_id = pa.project_id" +
+        "  inner join users a" +
+        "    on pa.author_id = a.user_id " +
+        "where p.visibility in ('PUBLIC', 'INTERNAL')" +
+        "  OR (pa.author_id = :userId) " +
+        "order by p.project_id desc " +
+        "limit :limit")
+    List<ProjectAndAuthor> getProjectsVisibleToUser(int userId, int limit);
 }

--- a/src/main/java/com/recurse/portfolio/data/UserRepository.java
+++ b/src/main/java/com/recurse/portfolio/data/UserRepository.java
@@ -3,6 +3,7 @@ package com.recurse.portfolio.data;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository
@@ -10,4 +11,18 @@ public interface UserRepository
 {
     @Query("select * from users where recurse_profile_id = :recurseProfileId")
     Optional<User> findByRecurseProfileId(int recurseProfileId);
+
+    @Query(
+        "select p.* " +
+            "from projects p" +
+            "  inner join project_authors pa" +
+            "    on p.project_id = pa.project_id " +
+            "where pa.author_id = :authorId" +
+            "  and p.visibility in (:visibilities) " +
+            "order by p.project_id asc"
+    )
+    List<Project> findProjectsByAuthor(
+        int authorId,
+        List<String> visibilities
+    );
 }

--- a/src/main/java/com/recurse/portfolio/web/HomeController.java
+++ b/src/main/java/com/recurse/portfolio/web/HomeController.java
@@ -1,13 +1,40 @@
 package com.recurse.portfolio.web;
 
+import com.recurse.portfolio.data.Project;
+import com.recurse.portfolio.data.ProjectAndAuthor;
+import com.recurse.portfolio.data.ProjectRepository;
+import com.recurse.portfolio.data.User;
+import com.recurse.portfolio.security.CurrentUser;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.util.Collection;
+
 @Controller
 public class HomeController {
+    private static final int LIMIT = 20;
+
+    @Autowired
+    ProjectRepository projectRepository;
+
     @GetMapping("/")
-    public ModelAndView index() {
-        return new ModelAndView("home");
+    public ModelAndView index(@CurrentUser User currentUser) {
+        return new ModelAndView("home")
+            .addObject("projects", projectsForUser(currentUser));
+    }
+
+    private Collection<Project> projectsForUser(User currentUser) {
+        if (currentUser == null) {
+            var projectAuthors = projectRepository.getPublicProjects(LIMIT);
+            return ProjectAndAuthor.collect(projectAuthors);
+        } else {
+            var projectAuthors = projectRepository.getProjectsVisibleToUser(
+                currentUser.getUserId(),
+                LIMIT
+            );
+            return ProjectAndAuthor.collect(projectAuthors);
+        }
     }
 }

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -34,7 +34,7 @@ footer {
   text-align: center;
 }
 
-.user {
+.user-details {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-evenly;

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -5,7 +5,39 @@
 </head>
 <body>
 <main>
-  <p>Content will go here.</p>
+  <h1>Recent Projects</h1>
+  <ul class="global-project-list">
+    <li
+      class="global-project-list-item"
+      data-th-each="project : ${projects}"
+    >
+      <a
+        href="projects/public.html"
+        data-th-href="@{/project/{id}(id=${project.projectId})}"
+        data-th-text="${project.name}"
+      >Project Name</a>,
+      by
+      <span
+        class="global-project-list-item-author"
+        data-th-each="author : ${project.authors}"
+      >
+        <a
+          href="users/public.html"
+          data-th-href="@{/user/{id}(id=${author.userId})}"
+          data-th-text="${author.publicName}"
+        >Author Name</a><span
+        data-th-if="not ${authorStat.last}"
+      >, </span>
+      </span>
+    </li>
+    <li
+      class="global-project-list-item"
+      data-th-remove="all"
+    >
+      <a href="../projects/public.html">Second Project</a>,
+      by <a href="users/public.html">Second Author</a>
+    </li>
+  </ul>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -11,7 +11,7 @@
     data-th-action="@{/user/{id}/edit(id=${user.userId})}"
     method="post"
   >
-    <section class="user">
+    <section class="user-details">
       <section class="user-view">
         <h2 class="user-section-title">Internal</h2>
         <label>

--- a/src/main/resources/templates/users/peer.html
+++ b/src/main/resources/templates/users/peer.html
@@ -63,6 +63,11 @@
       </div>
     </section>
   </section>
+  <section
+    data-th-replace="~{users/projects :: user-projects}"
+  >
+    Project List
+  </section>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/users/peer.html
+++ b/src/main/resources/templates/users/peer.html
@@ -8,54 +8,60 @@
 </head>
 <body>
 <main class="user">
-  <section class="user-view">
-    <h2 class="user-section-title">Internal</h2>
-    <img
-      class="user-image"
-      src="../../static/user-placeholder.png"
-      data-th-src="${user.internalImageUrl}"
-    />
-    <div class="user-name">
-      <span data-th-text="${user.internalName}">Internal Name</span>
-    </div>
-    <div class="user-bio">
-      Bio:
-      <div data-th-utext="${user.internalBio}">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum.
+  <section class="user-details">
+    <section class="user-view">
+      <h2 class="user-section-title">Internal</h2>
+      <img
+        class="user-image"
+        src="../../static/user-placeholder.png"
+        data-th-src="${user.internalImageUrl}"
+      />
+      <div class="user-name">
+        <span data-th-text="${user.internalName}">Internal Name</span>
       </div>
-    </div>
-  </section>
-  <section class="user-view">
-    <h2 class="user-section-title">Public</h2>
-    <img
-      class="user-image"
-      src="../../static/user-placeholder.png"
-      data-th-src="${user.publicImageUrl}"
-    />
-    <div class="user-name">
-      <span data-th-text="${user.publicName}">Public Name</span>
-    </div>
-    <div class="user-bio">
-      Bio:
-      <div data-th-utext="${user.publicBio}">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat
-        lobortis arcu vel feugiat. Nullam sagittis commodo turpis nec pretium.
-        Nulla bibendum ligula posuere malesuada posuere. Curabitur ullamcorper
-        sem ut lacus lacinia condimentum. Fusce quis tortor malesuada urna
-        posuere lacinia. Cras volutpat, augue ac semper ullamcorper, arcu metus
-        dapibus quam, ut dictum metus lacus vitae nibh. Pellentesque vitae diam
-        ut lacus efficitur mollis a id nisl. Phasellus ullamcorper ultricies
-        dolor. Maecenas condimentum magna sit amet venenatis sodales.
-        Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
-        pretium sit amet pulvinar non, mattis eu metus.
+      <div class="user-bio">
+        Bio:
+        <div data-th-utext="${user.internalBio}">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+          sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Duis aute irure dolor in reprehenderit in voluptate velit
+          esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+          occaecat cupidatat non proident, sunt in culpa qui officia
+          deserunt mollit anim id est laborum.
+        </div>
       </div>
-    </div>
+    </section>
+    <section class="user-view">
+      <h2 class="user-section-title">Public</h2>
+      <img
+        class="user-image"
+        src="../../static/user-placeholder.png"
+        data-th-src="${user.publicImageUrl}"
+      />
+      <div class="user-name">
+        <span data-th-text="${user.publicName}">Public Name</span>
+      </div>
+      <div class="user-bio">
+        Bio:
+        <div data-th-utext="${user.publicBio}">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Donec feugiat lobortis arcu vel feugiat. Nullam sagittis
+          commodo turpis nec pretium. Nulla bibendum ligula posuere
+          malesuada posuere. Curabitur ullamcorper sem ut lacus
+          lacinia condimentum. Fusce quis tortor malesuada urna
+          posuere lacinia. Cras volutpat, augue ac semper
+          ullamcorper, arcu metus dapibus quam, ut dictum metus lacus
+          vitae nibh. Pellentesque vitae diam ut lacus efficitur
+          mollis a id nisl. Phasellus ullamcorper ultricies dolor.
+          Maecenas condimentum magna sit amet venenatis sodales.
+          Pellentesque in pulvinar orci. Nulla facilisi. Vivamus
+          justo lorem, pretium sit amet pulvinar non, mattis eu
+          metus.
+        </div>
+      </div>
+    </section>
   </section>
 </main>
 </body>

--- a/src/main/resources/templates/users/projects.html
+++ b/src/main/resources/templates/users/projects.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Author Project List Fragment</title>
+  <link rel="stylesheet" href="../../static/style.css"/>
+</head>
+<body>
+<section
+  class="user-projects"
+  data-th-fragment="user-projects"
+>
+  <h2 class="user-projects-title">Projects</h2>
+  <ul class="user-project-list">
+    <li
+      class="user-project-list-item"
+      data-th-each="project : ${projects}"
+    >
+      <a
+        href="../projects/public.html"
+        data-th-href="@{/project/{id}(id=${project.projectId})}"
+        data-th-text="${project.name}"
+      >Project Name</a>
+    </li>
+    <li
+      class="user-project-list-item"
+      data-th-remove="all"
+    >
+      <a href="../projects/public.html">Second Project</a>
+    </li>
+  </ul>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/users/public.html
+++ b/src/main/resources/templates/users/public.html
@@ -38,6 +38,11 @@
       </div>
     </section>
   </section>
+  <section
+    data-th-replace="~{users/projects :: user-projects}"
+  >
+    Project List
+  </section>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/users/public.html
+++ b/src/main/resources/templates/users/public.html
@@ -8,30 +8,35 @@
 </head>
 <body>
 <main class="user">
-  <section class="user-view">
-    <img
-      class="user-image"
-      src="../../static/user-placeholder.png"
-      data-th-src="${user.publicImageUrl}"
-    />
-    <div class="user-name">
-      <span data-th-text="${user.publicName}">Public Name</span>
-    </div>
-    <div class="user-bio">
-      Bio:
-      <div data-th-utext="${user.publicBio}">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat
-        lobortis arcu vel feugiat. Nullam sagittis commodo turpis nec pretium.
-        Nulla bibendum ligula posuere malesuada posuere. Curabitur ullamcorper
-        sem ut lacus lacinia condimentum. Fusce quis tortor malesuada urna
-        posuere lacinia. Cras volutpat, augue ac semper ullamcorper, arcu metus
-        dapibus quam, ut dictum metus lacus vitae nibh. Pellentesque vitae diam
-        ut lacus efficitur mollis a id nisl. Phasellus ullamcorper ultricies
-        dolor. Maecenas condimentum magna sit amet venenatis sodales.
-        Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
-        pretium sit amet pulvinar non, mattis eu metus.
+  <section class="user-details">
+    <section class="user-view">
+      <img
+        class="user-image"
+        src="../../static/user-placeholder.png"
+        data-th-src="${user.publicImageUrl}"
+      />
+      <div class="user-name">
+        <span data-th-text="${user.publicName}">Public Name</span>
       </div>
-    </div>
+      <div class="user-bio">
+        Bio:
+        <div data-th-utext="${user.publicBio}">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Donec feugiat lobortis arcu vel feugiat. Nullam sagittis
+          commodo turpis nec pretium. Nulla bibendum ligula posuere
+          malesuada posuere. Curabitur ullamcorper sem ut lacus
+          lacinia condimentum. Fusce quis tortor malesuada urna
+          posuere lacinia. Cras volutpat, augue ac semper
+          ullamcorper, arcu metus dapibus quam, ut dictum metus lacus
+          vitae nibh. Pellentesque vitae diam ut lacus efficitur
+          mollis a id nisl. Phasellus ullamcorper ultricies dolor.
+          Maecenas condimentum magna sit amet venenatis sodales.
+          Pellentesque in pulvinar orci. Nulla facilisi. Vivamus
+          justo lorem, pretium sit amet pulvinar non, mattis eu
+          metus.
+        </div>
+      </div>
+    </section>
   </section>
 </main>
 </body>

--- a/src/main/resources/templates/users/self.html
+++ b/src/main/resources/templates/users/self.html
@@ -64,7 +64,7 @@
     </section>
   </section>
   <section class="user-settings">
-    <h2 class="user-section-title">Settings</h2>
+    <h2 class="user-settings-title">Settings</h2>
     <div>
       Profile visibility: <span data-th-text="${user.profileVisibility}">visibility</span>
     </div>
@@ -74,6 +74,11 @@
         data-th-href="@{/user/{id}/edit(id=${user.userId})}"
       >Edit</a>
     </div>
+  </section>
+  <section
+    data-th-replace="~{users/projects :: user-projects}"
+  >
+    Project List
   </section>
 </main>
 </body>

--- a/src/main/resources/templates/users/self.html
+++ b/src/main/resources/templates/users/self.html
@@ -8,54 +8,60 @@
 </head>
 <body>
 <main class="user">
-  <section class="user-view">
-    <h2 class="user-section-title">Internal</h2>
-    <img
-      class="user-image"
-      src="../../static/user-placeholder.png"
-      data-th-src="${user.internalImageUrl}"
-    />
-    <div class="user-name">
-      <span data-th-text="${user.internalName}">Internal Name</span>
-    </div>
-    <div class="user-bio">
-      Bio:
-      <div data-th-utext="${user.internalBio}">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum.
+  <section class="user-details">
+    <section class="user-view">
+      <h2 class="user-section-title">Internal</h2>
+      <img
+        class="user-image"
+        src="../../static/user-placeholder.png"
+        data-th-src="${user.internalImageUrl}"
+      />
+      <div class="user-name">
+        <span data-th-text="${user.internalName}">Internal Name</span>
       </div>
-    </div>
-  </section>
-  <section class="user-view">
-    <h2 class="user-section-title">Public</h2>
-    <img
-      class="user-image"
-      src="../../static/user-placeholder.png"
-      data-th-src="${user.publicImageUrl}"
-    />
-    <div class="user-name">
-      <span data-th-text="${user.publicName}">Public Name</span>
-    </div>
-    <div class="user-bio">
-      Bio:
-      <div data-th-utext="${user.publicBio}">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec feugiat
-        lobortis arcu vel feugiat. Nullam sagittis commodo turpis nec pretium.
-        Nulla bibendum ligula posuere malesuada posuere. Curabitur ullamcorper
-        sem ut lacus lacinia condimentum. Fusce quis tortor malesuada urna
-        posuere lacinia. Cras volutpat, augue ac semper ullamcorper, arcu metus
-        dapibus quam, ut dictum metus lacus vitae nibh. Pellentesque vitae diam
-        ut lacus efficitur mollis a id nisl. Phasellus ullamcorper ultricies
-        dolor. Maecenas condimentum magna sit amet venenatis sodales.
-        Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
-        pretium sit amet pulvinar non, mattis eu metus.
+      <div class="user-bio">
+        Bio:
+        <div data-th-utext="${user.internalBio}">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+          sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+          ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Duis aute irure dolor in reprehenderit in voluptate velit
+          esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+          occaecat cupidatat non proident, sunt in culpa qui officia
+          deserunt mollit anim id est laborum.
+        </div>
       </div>
-    </div>
+    </section>
+    <section class="user-view">
+      <h2 class="user-section-title">Public</h2>
+      <img
+        class="user-image"
+        src="../../static/user-placeholder.png"
+        data-th-src="${user.publicImageUrl}"
+      />
+      <div class="user-name">
+        <span data-th-text="${user.publicName}">Public Name</span>
+      </div>
+      <div class="user-bio">
+        Bio:
+        <div data-th-utext="${user.publicBio}">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Donec feugiat lobortis arcu vel feugiat. Nullam sagittis
+          commodo turpis nec pretium. Nulla bibendum ligula posuere
+          malesuada posuere. Curabitur ullamcorper sem ut lacus
+          lacinia condimentum. Fusce quis tortor malesuada urna
+          posuere lacinia. Cras volutpat, augue ac semper
+          ullamcorper, arcu metus dapibus quam, ut dictum metus lacus
+          vitae nibh. Pellentesque vitae diam ut lacus efficitur
+          mollis a id nisl. Phasellus ullamcorper ultricies dolor.
+          Maecenas condimentum magna sit amet venenatis sodales.
+          Pellentesque in pulvinar orci. Nulla facilisi. Vivamus
+          justo lorem, pretium sit amet pulvinar non, mattis eu
+          metus.
+        </div>
+      </div>
+    </section>
   </section>
   <section class="user-settings">
     <h2 class="user-section-title">Settings</h2>


### PR DESCRIPTION
List recently created projects on the home page, and list all of an author's projects (according to visibility) on their user page.

This doesn't include any styling; for now it's just a bare list. Once we add tags (#5), I think we'll have enough more to work with that something fancier will be worthwhile.

There is a lurking surprise in the home page list, which isn't yet a problem but someday will be: it fetches the 20 most recent project-author pairs; once we have multi-author projects (#37), a project with two authors would take up 2 of those 20 slots, and there would be one fewer project shown. Correspondingly, if the 20th-most-recent project had multiple authors, only one of them would be shown. Probably the solution will be to split the "get the most recent projects" (and have that use [`Pageable`](https://docs.spring.io/spring-data/jdbc/docs/1.0.6.RELEASE/reference/html/#repositories.core-concepts)) and "get the project-author pairs" queries (and probably that will need to become "get the project-author-tag tuples").

Resolves #32 Browse projects