### PR TITLE
Require HTTPS on Heroku

### DIFF
--- a/src/main/java/com/recurse/portfolio/security/SecurityConfiguration.java
+++ b/src/main/java/com/recurse/portfolio/security/SecurityConfiguration.java
@@ -12,7 +12,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
+        http.requiresChannel()
+            .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null)
+            .requiresSecure()
+            .and()
+            .authorizeRequests()
             .regexMatchers(".*\\?login$").authenticated()
             .and()
             .oauth2Login()


### PR DESCRIPTION
Follow the [Heroku docs on enabling HTTPS](https://devcenter.heroku.com/articles/preparing-a-spring-boot-app-for-production-on-heroku#force-the-use-of-https). As it suggests, this only requires HTTPS in a proxy environment, which allows for HTTP in a dev environment. Spring also automatically adds the [HSTS header](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) on secure connections.

Resolves #38 Redirect http to https