### PR TITLE
Add a default public profile picture

### DIFF
--- a/src/main/java/com/recurse/portfolio/security/PortfolioOAuth2UserService.java
+++ b/src/main/java/com/recurse/portfolio/security/PortfolioOAuth2UserService.java
@@ -43,7 +43,7 @@ public class PortfolioOAuth2UserService
             .internalName(profile.getName())
             .publicName(profile.getName())
             .internalImageUrl(profile.getImageUrl())
-            .publicImageUrl(null)
+            .publicImageUrl("/user-placeholder.png")
             .internalBio("")
             .publicBio("")
             .build()


### PR DESCRIPTION
Set the public image for new profiles to the placeholder user image, which was originally only used for layout. That way, if and when they set their profile to be public, the default behavior is to have some kind of image rather than none at all.

Resolves #43 Use placeholder image for new users