### PR TITLE
Add Markdown help link to new project page

### DIFF
--- a/src/main/resources/templates/projects/new.html
+++ b/src/main/resources/templates/projects/new.html
@@ -73,6 +73,9 @@ quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
 non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
 Cras ultrices rutrum tristique.
           </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </section>
         <section class="project-description">
           <h2 class="project-description-visibility">Internal</h2>
@@ -89,7 +92,10 @@ amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
 orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
 tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
 lacinia neque.
-        </textarea>
+          </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </section>
         <section class="project-description">
           <h2 class="project-description-visibility">Public</h2>
@@ -111,7 +117,10 @@ leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
 sem in, malesuada ornare tortor. Proin id fermentum justo, sed
 condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
 at egestas.
-        </textarea>
+          </textarea>
+          <a href="https://commonmark.org/help/">
+            Styling with Markdown is supported.
+          </a>
         </section>
       </section>
       <section class="project-settings">


### PR DESCRIPTION
Update the new project page to match the edit project page by adding the Markdown help link before each description.

Issue #23 Parse descriptions as markdown