### PR TITLE
Add error pages

### DIFF
--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
+<head>
+  <title>Page Not Found</title>
+  <link rel="stylesheet" href="../../static/style.css"/>
+</head>
+<body>
+<main class="error404">
+  <h1 class="error404-title">
+    404 Page Not Found
+  </h1>
+  <div class="error404-explanation">
+    There's nothing here!
+  </div>
+  <div
+    class="error404-solutions"
+    data-th-if="${currentUser}"
+  >
+    <p>
+      Would you like to start over by
+      <a href="/">going home</a>?
+    </p>
+  </div>
+  <div
+    class="error404-solutions"
+    data-th-unless="${currentUser}"
+  >
+    <p>
+      You could try
+      <a href="?login">logging in</a>,
+      that might fix it.
+    </p>
+    <p>
+      Or, you could start over by
+      <a href="/">going home</a>.
+    </p>
+  </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
+<head>
+  <title>Server Error</title>
+  <link rel="stylesheet" href="../../static/style.css"/>
+</head>
+<body>
+<main class="error5xx">
+  <h1
+    class="error5xx-title"
+    data-th-text="|${status} ${error}|"
+  >
+    Server Error
+  </h1>
+  <div class="error5xx-explanation">
+    Oh no! Something went wrong!
+  </div>
+  <div
+    class="error5xx-solutions"
+  >
+    <p>
+      Please
+      <a
+        href="https://github.com/jasonaowen/recurse-community-portfolio/issues/new"
+        data-th-href="|https://github.com/jasonaowen/recurse-community-portfolio/issues/new?body=I+encountered+a+${status}+${error}+accessing+`${path}`+at+${#dates.formatISO(timestamp)}.|"
+      >
+        file an issue</a>,
+      and be sure to include the path
+      (<span data-th-text="${path}">path</span>)
+      and the current time
+      (<span
+        data-th-text="${#dates.formatISO(timestamp)}"
+      >timestamp</span>)
+      so that the error can be associated with the server logs.
+    </p>
+  </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Add error page templates under the names that [Spring automatically looks for](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-error-handling) to handle 404 and 5xx errors. The 404 page includes a prompt to log in, if applicable, and the 5xx includes a link to file an issue on GitHub.

![404-logged-out](https://user-images.githubusercontent.com/1494855/57031777-9ec06500-6c16-11e9-8577-92d2728ce0d7.png)
![404-logged-in](https://user-images.githubusercontent.com/1494855/57031778-9f58fb80-6c16-11e9-8045-e12157668db6.png)
![5xx-error](https://user-images.githubusercontent.com/1494855/57031779-9f58fb80-6c16-11e9-91f5-162a22cd294f.png)

Resolves #16 Add default error handler page