### PR TITLE
Clarify visibility options

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -148,6 +148,13 @@ footer {
   text-align: center;
 }
 
+.settings-visibility-list {
+  list-style-type: none;
+  margin: auto;
+  text-align: left;
+  width: max-content;
+}
+
 .project-input {
   display: flex;
   flex-direction: column;

--- a/src/main/resources/templates/projects/author.html
+++ b/src/main/resources/templates/projects/author.html
@@ -91,9 +91,10 @@
     </section>
   </section>
   <section class="project-settings">
-    <div>
-      Visibility:
-      <span data-th-text="${project.visibility}">visibility</span>
+    <div
+      data-th-replace="~{visibility :: view('Project visibility', ${project.visibility})}"
+    >
+      Project visibility fragment
     </div>
     <div>
       <a

--- a/src/main/resources/templates/projects/edit.html
+++ b/src/main/resources/templates/projects/edit.html
@@ -130,18 +130,10 @@ at egestas.
         </section>
       </section>
       <section class="project-settings">
-        <div>
-          Visibility:
-          <select name="visibility">
-            <option
-              data-th-each="v : ${T(com.recurse.portfolio.security.Visibility).values()}"
-              data-th-value="${v}"
-              data-th-selected="*{visibility} == ${v}"
-              data-th-text="${v}"
-            >
-              visibility
-            </option>
-          </select>
+        <div
+          data-th-replace="~{visibility :: settings('Project visibility', *{visibility}, 'visibility')}"
+        >
+          Project visiblity fragment
         </div>
         <div>
           <input type="submit"/>

--- a/src/main/resources/templates/projects/new.html
+++ b/src/main/resources/templates/projects/new.html
@@ -130,18 +130,10 @@ at egestas.
         </section>
       </section>
       <section class="project-settings">
-        <div>
-          Visibility:
-          <select name="visibility">
-            <option
-              data-th-each="v : ${T(com.recurse.portfolio.security.Visibility).values()}"
-              data-th-value="${v}"
-              data-th-selected="*{visibility} == ${v}"
-              data-th-text="${v}"
-            >
-              visibility
-            </option>
-          </select>
+        <div
+          data-th-replace="~{visibility :: settings('Project visibility', *{visibility}, 'visibility')}"
+        >
+          Project visiblity fragment
         </div>
         <div>
           <input type="submit"/>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -105,19 +105,11 @@ pretium sit amet pulvinar non, mattis eu metus.
       </section>
     </section>
     <section class="user-settings">
-      <label>
-        Profile visibility:
-        <select name="profileVisibility">
-          <option
-            data-th-each="v : ${T(com.recurse.portfolio.security.Visibility).values()}"
-            data-th-value="${v}"
-            data-th-selected="*{profileVisibility} == ${v}"
-            data-th-text="${v}"
-          >
-            visibility
-          </option>
-        </select>
-      </label>
+      <div
+        data-th-replace="~{visibility :: settings('Profile visibility', *{profileVisibility}, 'profileVisibility')}"
+      >
+        Profile visiblity fragment
+      </div>
       <div>
         <input type="submit"/>
       </div>

--- a/src/main/resources/templates/users/self.html
+++ b/src/main/resources/templates/users/self.html
@@ -65,8 +65,10 @@
   </section>
   <section class="user-settings">
     <h2 class="user-settings-title">Settings</h2>
-    <div>
-      Profile visibility: <span data-th-text="${user.profileVisibility}">visibility</span>
+    <div
+      data-th-replace="~{visibility :: view('Profile visibility', ${user.profileVisibility})}"
+    >
+      Profile visibility fragment
     </div>
     <div>
       <a

--- a/src/main/resources/templates/visibility.html
+++ b/src/main/resources/templates/visibility.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Visibility Fragments</title>
+  <link rel="stylesheet" href="../../static/style.css"/>
+</head>
+<body>
+<div
+  class="settings-visibility"
+  data-th-fragment="settings(title, currentVisibility, fieldName)"
+>
+  <span data-th-text="${title}">Visibility</span>:
+  <ul class="settings-visibility-list">
+    <li>
+      <label>
+        <input
+          type="radio"
+          name="visibility"
+          required
+          value="${T(com.recurse.portfolio.security.Visibility).PRIVATE}"
+          data-th-checked="${currentVisibility} == ${T(com.recurse.portfolio.security.Visibility).PRIVATE}"
+          data-th-name="${fieldName}"
+        />
+        Private - only you can view
+      </label>
+    </li>
+    <li>
+      <label>
+        <input
+          type="radio"
+          name="visibility"
+          required
+          value="${T(com.recurse.portfolio.security.Visibility).INTERNAL}"
+          data-th-checked="${currentVisibility} == ${T(com.recurse.portfolio.security.Visibility).INTERNAL}"
+          data-th-name="${fieldName}"
+        />
+        Internal - other logged-in users can view
+      </label>
+    </li>
+    <li>
+      <label>
+        <input
+          type="radio"
+          name="visibility"
+          required
+          value="${T(com.recurse.portfolio.security.Visibility).PUBLIC}"
+          data-th-checked="${currentVisibility} == ${T(com.recurse.portfolio.security.Visibility).PUBLIC}"
+          data-th-name="${fieldName}"
+        />
+        Public - anyone can view
+      </label>
+    </li>
+  </ul>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/visibility.html
+++ b/src/main/resources/templates/visibility.html
@@ -52,5 +52,19 @@
     </li>
   </ul>
 </div>
+<div
+  data-th-fragment="view(title, currentVisibility)"
+>
+  <span data-th-text="${title}">Visibility</span>:
+  <span
+    data-th-if="${currentVisibility} == ${T(com.recurse.portfolio.security.Visibility).PRIVATE}"
+  >only you can view</span>
+  <span
+    data-th-if="${currentVisibility} == ${T(com.recurse.portfolio.security.Visibility).INTERNAL}"
+  >other logged-in users can view</span>
+  <span
+    data-th-if="${currentVisibility} == ${T(com.recurse.portfolio.security.Visibility).PUBLIC}"
+  >anyone can view</span>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Replace the visibility drop-down filled with all-caps settings with radio buttons and explanatory labels, and replace the all-caps PRIVATE/INTERNAL/PUBLIC values in the author's view of a project and a user's view of themself.

Profile edit, before:
![Screenshot 2019-05-03 14:12:30](https://user-images.githubusercontent.com/1494855/57157122-c990f180-6dad-11e9-9af9-fe688da13be2.png)

Profile edit, after:
![Screenshot 2019-05-03 14:13:06](https://user-images.githubusercontent.com/1494855/57157121-c990f180-6dad-11e9-8012-569ba57012cf.png)

Resolves #41 Make visibility options clearer