### PR TITLE
Protect author privacy

### DIFF
--- a/src/main/java/com/recurse/portfolio/web/DisplayAuthor.java
+++ b/src/main/java/com/recurse/portfolio/web/DisplayAuthor.java
@@ -1,0 +1,64 @@
+package com.recurse.portfolio.web;
+
+import com.recurse.portfolio.data.User;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+public class DisplayAuthor {
+    int userId;
+    String name;
+    String imageUrl;
+
+    public static DisplayAuthor fromUserForUser(
+        @NonNull User sourceUser,
+        User requestingUser
+    ) {
+        switch(sourceUser.getProfileVisibility()) {
+            case PRIVATE:
+                if (sourceUser == requestingUser) {
+                    return useInternal(sourceUser);
+                } else {
+                    return anonymous();
+                }
+            case INTERNAL:
+                if (requestingUser == null) {
+                    return anonymous();
+                } else {
+                    return useInternal(sourceUser);
+                }
+            case PUBLIC:
+                if (requestingUser == null) {
+                    return usePublic(sourceUser);
+                } else {
+                    return useInternal(sourceUser);
+                }
+            default:
+                return anonymous();
+        }
+    }
+
+    private static DisplayAuthor anonymous() {
+        return new DisplayAuthor(
+            0,
+            "Anonymous",
+            "/user-placeholder.png"
+        );
+    }
+
+    private static DisplayAuthor usePublic(User user) {
+        return new DisplayAuthor(
+            user.getUserId(),
+            user.getPublicName(),
+            user.getPublicImageUrl()
+        );
+    }
+
+    private static DisplayAuthor useInternal(User user) {
+        return new DisplayAuthor(
+            user.getUserId(),
+            user.getInternalName(),
+            user.getInternalImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/recurse/portfolio/web/DisplayProject.java
+++ b/src/main/java/com/recurse/portfolio/web/DisplayProject.java
@@ -1,0 +1,28 @@
+package com.recurse.portfolio.web;
+
+import com.recurse.portfolio.data.Project;
+import com.recurse.portfolio.data.User;
+import lombok.Value;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Value
+public class DisplayProject {
+    int projectId;
+    String name;
+    Set<DisplayAuthor> authors;
+
+    public static DisplayProject fromProjectForUser(
+        Project project,
+        User currentUser
+    ) {
+        return new DisplayProject(
+            project.getProjectId(),
+            project.getName(),
+            project.getAuthors().stream()
+                .map(u -> DisplayAuthor.fromUserForUser(u, currentUser))
+                .collect(Collectors.toUnmodifiableSet())
+        );
+    }
+}

--- a/src/main/java/com/recurse/portfolio/web/HomeController.java
+++ b/src/main/java/com/recurse/portfolio/web/HomeController.java
@@ -1,6 +1,5 @@
 package com.recurse.portfolio.web;
 
-import com.recurse.portfolio.data.Project;
 import com.recurse.portfolio.data.ProjectAndAuthor;
 import com.recurse.portfolio.data.ProjectRepository;
 import com.recurse.portfolio.data.User;
@@ -11,6 +10,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 public class HomeController {
@@ -22,19 +23,23 @@ public class HomeController {
     @GetMapping("/")
     public ModelAndView index(@CurrentUser User currentUser) {
         return new ModelAndView("home")
-            .addObject("projects", projectsForUser(currentUser));
+            .addObject("projects", displayProjectsForUser(currentUser));
     }
 
-    private Collection<Project> projectsForUser(User currentUser) {
+    private Collection<DisplayProject> displayProjectsForUser(User currentUser) {
+        return ProjectAndAuthor.collect(projectsForUser(currentUser)).stream()
+            .map(p -> DisplayProject.fromProjectForUser(p, currentUser))
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    private List<ProjectAndAuthor> projectsForUser(User currentUser) {
         if (currentUser == null) {
-            var projectAuthors = projectRepository.getPublicProjects(LIMIT);
-            return ProjectAndAuthor.collect(projectAuthors);
+            return projectRepository.getPublicProjects(LIMIT);
         } else {
-            var projectAuthors = projectRepository.getProjectsVisibleToUser(
+            return projectRepository.getProjectsVisibleToUser(
                 currentUser.getUserId(),
                 LIMIT
             );
-            return ProjectAndAuthor.collect(projectAuthors);
         }
     }
 }

--- a/src/main/java/com/recurse/portfolio/web/ProjectController.java
+++ b/src/main/java/com/recurse/portfolio/web/ProjectController.java
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import javax.validation.Valid;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.recurse.portfolio.web.MarkdownHelper.renderMarkdownToHtml;
 
@@ -37,7 +38,8 @@ public class ProjectController {
         var project = new Project();
         project.setVisibility(Visibility.PRIVATE);
         return new ModelAndView("projects/new")
-            .addObject("authors", Set.of(currentUser))
+            .addObject("authors", Set.of(
+                DisplayAuthor.fromUserForUser(currentUser, currentUser)))
             .addObject("project", project);
     }
 
@@ -95,9 +97,12 @@ public class ProjectController {
             project.getPrivateDescription()
         ));
 
+        Set<DisplayAuthor> displayAuthors = authors.stream()
+            .map(a -> DisplayAuthor.fromUserForUser(a, currentUser))
+            .collect(Collectors.toUnmodifiableSet());
         return new ModelAndView(policy.evaluate(authors, currentUser))
             .addObject("project", project)
-            .addObject("authors", authors);
+            .addObject("authors", displayAuthors);
     }
 
     @GetMapping("/project/{projectId}/edit")
@@ -113,9 +118,12 @@ public class ProjectController {
             throw new VisibilityException(Visibility.PRIVATE);
         }
 
+        Set<DisplayAuthor> displayAuthors = authors.stream()
+            .map(a -> DisplayAuthor.fromUserForUser(a, currentUser))
+            .collect(Collectors.toUnmodifiableSet());
         return new ModelAndView("projects/edit")
             .addObject("project", project)
-            .addObject("authors", authors);
+            .addObject("authors", displayAuthors);
     }
 
     @PostMapping("/project/{id}/edit")

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -24,7 +24,7 @@
         <a
           href="users/public.html"
           data-th-href="@{/user/{id}(id=${author.userId})}"
-          data-th-text="${author.publicName}"
+          data-th-text="${author.name}"
         >Author Name</a><span
         data-th-if="not ${authorStat.last}"
       >, </span>

--- a/src/main/resources/templates/projects/author.html
+++ b/src/main/resources/templates/projects/author.html
@@ -12,39 +12,8 @@
   >
     Project Name
   </h1>
-  <section class="project-authors">
-    By:
-    <ul class="project-authors-list">
-      <li
-        class="project-authors-list-item"
-        data-th-each="author : ${authors}"
-      >
-        <a
-          class="project-author-list-item-link"
-          href="../users/self.html"
-          data-th-href="@{/user/{id}(id=${author.userId})}"
-        >
-          <img
-            class="project-author-list-item-image"
-            src="../../static/user-placeholder.png"
-            data-th-src="${author.internalImageUrl}"
-          />
-          <span data-th-text="${author.internalName}">My Self</span>
-        </a>
-      </li>
-      <li
-        class="project-authors-list-item"
-        data-th-remove="all"
-      >
-        <a class="project-author-list-item-link" href="../users/peer.html">
-          <img
-            class="project-author-list-item-image"
-            src="../../static/user-placeholder.png"
-          />
-          <span>Peer Author</span>
-        </a>
-      </li>
-    </ul>
+  <section data-th-replace="~{projects/common :: authorsList(${authors})}">
+    <a href="common.html">Authors list fragment</a>
   </section>
   <section class="project-descriptions">
     <section class="project-description">

--- a/src/main/resources/templates/projects/author.html
+++ b/src/main/resources/templates/projects/author.html
@@ -23,14 +23,13 @@
           class="project-author-list-item-link"
           href="../users/self.html"
           data-th-href="@{/user/{id}(id=${author.userId})}"
-          data-th-text="${author.internalName}"
         >
           <img
             class="project-author-list-item-image"
             src="../../static/user-placeholder.png"
             data-th-src="${author.internalImageUrl}"
           />
-          My Self
+          <span data-th-text="${author.internalName}">My Self</span>
         </a>
       </li>
       <li
@@ -42,7 +41,7 @@
             class="project-author-list-item-image"
             src="../../static/user-placeholder.png"
           />
-          Peer Author
+          <span>Peer Author</span>
         </a>
       </li>
     </ul>

--- a/src/main/resources/templates/projects/common.html
+++ b/src/main/resources/templates/projects/common.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Project Shared Fragments</title>
+  <link rel="stylesheet" href="../../static/style.css"/>
+</head>
+<body>
+<section class="project-authors" data-th-fragment="authorsList(authors)">
+  By:
+  <ul class="project-authors-list">
+    <li
+      class="project-authors-list-item"
+      data-th-each="author : ${authors}"
+    >
+      <a
+        class="project-author-list-item-link"
+        href="../users/self.html"
+        data-th-href="@{/user/{id}(id=${author.userId})}"
+      >
+        <img
+          class="project-author-list-item-image"
+          src="../../static/user-placeholder.png"
+          data-th-src="${author.imageUrl}"
+        />
+        <span data-th-text="${author.name}">My Self</span>
+      </a>
+    </li>
+    <li
+      class="project-authors-list-item"
+      data-th-remove="all"
+    >
+      <a class="project-author-list-item-link" href="../users/peer.html">
+        <img
+          class="project-author-list-item-image"
+          src="../../static/user-placeholder.png"
+        />
+        <span>Peer Author</span>
+      </a>
+    </li>
+    <li
+      class="project-authors-list-item"
+      data-th-remove="all"
+    >
+      <a class="project-author-list-item-link" href="../users/public.html">
+        <img
+          class="project-author-list-item-image"
+          src="../../static/user-placeholder.png"
+        />
+        <span>Public Author</span>
+      </a>
+    </li>
+  </ul>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/projects/edit.html
+++ b/src/main/resources/templates/projects/edit.html
@@ -39,14 +39,13 @@
               class="project-author-list-item-link"
               href="../users/self.html"
               data-th-href="@{/user/{id}(id=${author.userId})}"
-              data-th-text="${author.internalName}"
             >
               <img
                 class="project-author-list-item-image"
                 src="../../static/user-placeholder.png"
                 data-th-src="${author.internalImageUrl}"
               />
-              My Self
+              <span data-th-text="${author.internalName}">My Self</span>
             </a>
           </li>
           <li
@@ -58,7 +57,7 @@
                 class="project-author-list-item-image"
                 src="../../static/user-placeholder.png"
               />
-              Peer Author
+              <span>Peer Author</span>
             </a>
           </li>
         </ul>

--- a/src/main/resources/templates/projects/edit.html
+++ b/src/main/resources/templates/projects/edit.html
@@ -28,39 +28,8 @@
           />
         </label>
       </section>
-      <section class="project-authors">
-        By:
-        <ul class="project-authors-list">
-          <li
-            class="project-authors-list-item"
-            data-th-each="author : ${authors}"
-          >
-            <a
-              class="project-author-list-item-link"
-              href="../users/self.html"
-              data-th-href="@{/user/{id}(id=${author.userId})}"
-            >
-              <img
-                class="project-author-list-item-image"
-                src="../../static/user-placeholder.png"
-                data-th-src="${author.internalImageUrl}"
-              />
-              <span data-th-text="${author.internalName}">My Self</span>
-            </a>
-          </li>
-          <li
-            class="project-authors-list-item"
-            data-th-remove="all"
-          >
-            <a class="project-author-list-item-link" href="../users/peer.html">
-              <img
-                class="project-author-list-item-image"
-                src="../../static/user-placeholder.png"
-              />
-              <span>Peer Author</span>
-            </a>
-          </li>
-        </ul>
+      <section data-th-replace="~{projects/common :: authorsList(${authors})}">
+        <a href="common.html">Authors list fragment</a>
       </section>
       <section class="project-descriptions">
         <section class="project-description">

--- a/src/main/resources/templates/projects/new.html
+++ b/src/main/resources/templates/projects/new.html
@@ -28,39 +28,8 @@
           />
         </label>
       </section>
-      <section class="project-authors">
-        By:
-        <ul class="project-authors-list">
-          <li
-            class="project-authors-list-item"
-            data-th-each="author : ${authors}"
-          >
-            <a
-              class="project-author-list-item-link"
-              href="../users/self.html"
-              data-th-href="@{/user/{id}(id=${author.userId})}"
-            >
-              <img
-                class="project-author-list-item-image"
-                src="../../static/user-placeholder.png"
-                data-th-src="${author.internalImageUrl}"
-              />
-              <span data-th-text="${author.internalName}">My Self</span>
-            </a>
-          </li>
-          <li
-            class="project-authors-list-item"
-            data-th-remove="all"
-          >
-            <a class="project-author-list-item-link" href="../users/peer.html">
-              <img
-                class="project-author-list-item-image"
-                src="../../static/user-placeholder.png"
-              />
-              Peer Author
-            </a>
-          </li>
-        </ul>
+      <section data-th-replace="~{projects/common :: authorsList(${authors})}">
+        <a href="common.html">Authors list fragment</a>
       </section>
       <section class="project-descriptions">
         <section class="project-description">

--- a/src/main/resources/templates/projects/new.html
+++ b/src/main/resources/templates/projects/new.html
@@ -39,14 +39,13 @@
               class="project-author-list-item-link"
               href="../users/self.html"
               data-th-href="@{/user/{id}(id=${author.userId})}"
-              data-th-text="${author.internalName}"
             >
               <img
                 class="project-author-list-item-image"
                 src="../../static/user-placeholder.png"
                 data-th-src="${author.internalImageUrl}"
               />
-              My Self
+              <span data-th-text="${author.internalName}">My Self</span>
             </a>
           </li>
           <li

--- a/src/main/resources/templates/projects/peer.html
+++ b/src/main/resources/templates/projects/peer.html
@@ -12,39 +12,8 @@
   >
     Project Name
   </h1>
-  <section class="project-authors">
-    By:
-    <ul class="project-authors-list">
-      <li
-        class="project-authors-list-item"
-        data-th-each="author : ${authors}"
-      >
-        <a
-          class="project-author-list-item-link"
-          href="../users/peer.html"
-          data-th-href="@{/user/{id}(id=${author.userId})}"
-        >
-          <img
-            class="project-author-list-item-image"
-            src="../../static/user-placeholder.png"
-            data-th-src="${author.internalImageUrl}"
-          />
-          <span data-th-text="${author.internalName}">Peer Author</span>
-        </a>
-      </li>
-      <li
-        class="project-authors-list-item"
-        data-th-remove="all"
-      >
-        <a class="project-author-list-item-link" href="../users/peer.html">
-          <img
-            class="project-author-list-item-image"
-            src="../../static/user-placeholder.png"
-          />
-          <span>Another Peer</span>
-        </a>
-      </li>
-    </ul>
+  <section data-th-replace="~{projects/common :: authorsList(${authors})}">
+    <a href="common.html">Authors list fragment</a>
   </section>
   <section class="project-descriptions">
     <section class="project-description">

--- a/src/main/resources/templates/projects/peer.html
+++ b/src/main/resources/templates/projects/peer.html
@@ -23,14 +23,13 @@
           class="project-author-list-item-link"
           href="../users/peer.html"
           data-th-href="@{/user/{id}(id=${author.userId})}"
-          data-th-text="${author.internalName}"
         >
           <img
             class="project-author-list-item-image"
             src="../../static/user-placeholder.png"
             data-th-src="${author.internalImageUrl}"
           />
-          Peer Author
+          <span data-th-text="${author.internalName}">Peer Author</span>
         </a>
       </li>
       <li
@@ -42,7 +41,7 @@
             class="project-author-list-item-image"
             src="../../static/user-placeholder.png"
           />
-          Another Peer
+          <span>Another Peer</span>
         </a>
       </li>
     </ul>

--- a/src/main/resources/templates/projects/public.html
+++ b/src/main/resources/templates/projects/public.html
@@ -12,39 +12,8 @@
   >
     Project Name
   </h1>
-  <section class="project-authors">
-    By:
-    <ul class="project-authors-list">
-      <li
-        class="project-authors-list-item"
-        data-th-each="author : ${authors}"
-      >
-        <a
-          class="project-author-list-item-link"
-          href="../users/public.html"
-          data-th-href="@{/user/{id}(id=${author.userId})}"
-        >
-          <img
-            class="project-author-list-item-image"
-            src="../../static/user-placeholder.png"
-            data-th-src="${author.publicImageUrl}"
-          />
-          <span data-th-text="${author.publicName}">First Author</span>
-        </a>
-      </li>
-      <li
-        class="project-authors-list-item"
-        data-th-remove="all"
-      >
-        <a class="project-author-list-item-link" href="../users/public.html">
-          <img
-            class="project-author-list-item-image"
-            src="../../static/user-placeholder.png"
-          />
-          <span>Second Author</span>
-        </a>
-      </li>
-    </ul>
+  <section data-th-replace="~{projects/common :: authorsList(${authors})}">
+    <a href="common.html">Authors list fragment</a>
   </section>
   <section class="project-descriptions">
     <section class="project-description">

--- a/src/main/resources/templates/projects/public.html
+++ b/src/main/resources/templates/projects/public.html
@@ -23,14 +23,13 @@
           class="project-author-list-item-link"
           href="../users/public.html"
           data-th-href="@{/user/{id}(id=${author.userId})}"
-          data-th-text="${author.publicName}"
         >
           <img
             class="project-author-list-item-image"
             src="../../static/user-placeholder.png"
             data-th-src="${author.publicImageUrl}"
           />
-          First Author
+          <span data-th-text="${author.publicName}">First Author</span>
         </a>
       </li>
       <li
@@ -42,7 +41,7 @@
             class="project-author-list-item-image"
             src="../../static/user-placeholder.png"
           />
-          Second Author
+          <span>Second Author</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
When the author of a visible project has their profile set to be not visible, do not show their name or picture; instead, show "Anonymous" and the user placeholder image.

Additionally, fix a bug where author pictures were not shown on project pages.

Public view:
![Screenshot 2019-05-06 12:33:58](https://user-images.githubusercontent.com/1494855/57239929-449b1780-6ffb-11e9-85dc-fe2b831fc1cd.png)

Author view:
![Screenshot 2019-05-06 12:33:45](https://user-images.githubusercontent.com/1494855/57239930-449b1780-6ffb-11e9-908a-ffc282fbcc10.png)

Resolves #46 Do not show author if profile is not visible