### PR TITLE
Update project layout to emphasize public description

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -128,20 +128,9 @@ footer {
   text-align: center;
 }
 
-.project-descriptions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
-}
-
-.project-description-visibility {
-  margin: 0;
-  text-align: center;
-}
-
 .project-description {
-  max-width: 24em;
-  margin: 1em;
+  max-width: 40em;
+  margin: 1em auto;
 }
 
 .project-settings {
@@ -162,8 +151,8 @@ footer {
 
 .project-input-description {
   display: block;
-  width: 24em;
-  height: 32em;
+  width: 100%;
+  height: 24em;
 }
 
 .input-error {

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -149,6 +149,10 @@ footer {
   flex-direction: column;
 }
 
+.project-description-visibility {
+  display: inline;
+}
+
 .project-input-description {
   display: block;
   width: 100%;

--- a/src/main/resources/templates/projects/author.html
+++ b/src/main/resources/templates/projects/author.html
@@ -16,7 +16,10 @@
     <a href="common.html">Authors list fragment</a>
   </section>
   <section class="project-descriptions">
-    <section class="project-description">
+    <section
+      class="project-description"
+      data-th-unless="${#strings.isEmpty(project.publicDescription)}"
+    >
       <h2 class="project-description-visibility">Public</h2>
       <div data-th-utext="${project.publicDescription}">
         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
@@ -34,7 +37,10 @@
         at egestas.
       </div>
     </section>
-    <section class="project-description">
+    <section
+      class="project-description"
+      data-th-unless="${#strings.isEmpty(project.internalDescription)}"
+    >
       <h2 class="project-description-visibility">Internal</h2>
       <div data-th-utext="${project.internalDescription}">
         Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
@@ -46,7 +52,10 @@
         lacinia neque.
       </div>
     </section>
-    <section class="project-description">
+    <section
+      class="project-description"
+      data-th-unless="${#strings.isEmpty(project.privateDescription)}"
+    >
       <h2 class="project-description-visibility">Private</h2>
       <div data-th-utext="${project.privateDescription}">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a

--- a/src/main/resources/templates/projects/author.html
+++ b/src/main/resources/templates/projects/author.html
@@ -17,29 +17,6 @@
   </section>
   <section class="project-descriptions">
     <section class="project-description">
-      <h2 class="project-description-visibility">Private</h2>
-      <div data-th-utext="${project.privateDescription}">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
-        justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
-        Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
-        quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
-        non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
-        Cras ultrices rutrum tristique.
-      </div>
-    </section>
-    <section class="project-description">
-      <h2 class="project-description-visibility">Internal</h2>
-      <div data-th-utext="${project.internalDescription}">
-        Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
-        euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
-        dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
-        amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
-        orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
-        tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
-        lacinia neque.
-      </div>
-    </section>
-    <section class="project-description">
       <h2 class="project-description-visibility">Public</h2>
       <div data-th-utext="${project.publicDescription}">
         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
@@ -55,6 +32,29 @@
         sem in, malesuada ornare tortor. Proin id fermentum justo, sed
         condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
         at egestas.
+      </div>
+    </section>
+    <section class="project-description">
+      <h2 class="project-description-visibility">Internal</h2>
+      <div data-th-utext="${project.internalDescription}">
+        Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
+        euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
+        dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
+        amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
+        orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
+        tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
+        lacinia neque.
+      </div>
+    </section>
+    <section class="project-description">
+      <h2 class="project-description-visibility">Private</h2>
+      <div data-th-utext="${project.privateDescription}">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
+        justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
+        Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
+        quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
+        non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
+        Cras ultrices rutrum tristique.
       </div>
     </section>
   </section>

--- a/src/main/resources/templates/projects/edit.html
+++ b/src/main/resources/templates/projects/edit.html
@@ -33,19 +33,25 @@
       </section>
       <section class="project-descriptions">
         <section class="project-description">
-          <h2 class="project-description-visibility">Private</h2>
+          <h2 class="project-description-visibility">Public</h2>
           <textarea
             class="project-input-description"
-            name="privateDescription"
-            placeholder="Private project description, visible only to you"
-            data-th-text="*{privateDescription}"
+            name="publicDescription"
+            data-th-text="*{publicDescription}"
           >
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
-justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
-Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
-quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
-non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
-Cras ultrices rutrum tristique.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
+mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
+odio. Ut non tincidunt turpis. Aenean convallis eu sapien nec elementum.
+Fusce facilisis sapien risus, eget imperdiet nisi accumsan nec. Nam
+venenatis tellus aliquam ipsum placerat, nec finibus libero dignissim.
+Donec maximus ipsum lectus, non viverra orci iaculis a. Integer purus
+urna, malesuada eu risus volutpat, elementum fermentum elit. Proin ex
+velit, efficitur sit amet tempus sit amet, maximus id ex. Nam lacinia ut
+leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
+sem in, malesuada ornare tortor. Proin id fermentum justo, sed
+condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
+at egestas.
           </textarea>
           <a href="https://commonmark.org/help/">
             Styling with Markdown is supported.
@@ -72,25 +78,19 @@ lacinia neque.
           </a>
         </section>
         <section class="project-description">
-          <h2 class="project-description-visibility">Public</h2>
+          <h2 class="project-description-visibility">Private</h2>
           <textarea
             class="project-input-description"
-            name="publicDescription"
-            data-th-text="*{publicDescription}"
+            name="privateDescription"
+            placeholder="Private project description, visible only to you"
+            data-th-text="*{privateDescription}"
           >
-Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
-cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
-mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
-odio. Ut non tincidunt turpis. Aenean convallis eu sapien nec elementum.
-Fusce facilisis sapien risus, eget imperdiet nisi accumsan nec. Nam
-venenatis tellus aliquam ipsum placerat, nec finibus libero dignissim.
-Donec maximus ipsum lectus, non viverra orci iaculis a. Integer purus
-urna, malesuada eu risus volutpat, elementum fermentum elit. Proin ex
-velit, efficitur sit amet tempus sit amet, maximus id ex. Nam lacinia ut
-leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
-sem in, malesuada ornare tortor. Proin id fermentum justo, sed
-condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
-at egestas.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
+justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
+Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
+quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
+non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
+Cras ultrices rutrum tristique.
           </textarea>
           <a href="https://commonmark.org/help/">
             Styling with Markdown is supported.

--- a/src/main/resources/templates/projects/edit.html
+++ b/src/main/resources/templates/projects/edit.html
@@ -33,12 +33,17 @@
       </section>
       <section class="project-descriptions">
         <section class="project-description">
-          <h2 class="project-description-visibility">Public</h2>
-          <textarea
-            class="project-input-description"
-            name="publicDescription"
-            data-th-text="*{publicDescription}"
+          <details
+            data-th-open="*{!#strings.isEmpty(publicDescription)}"
           >
+            <summary>
+              <h2 class="project-description-visibility">Public</h2>
+            </summary>
+            <textarea
+              class="project-input-description"
+              name="publicDescription"
+              data-th-text="*{publicDescription}"
+            >
 Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
 cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
 mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
@@ -52,19 +57,25 @@ leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
 sem in, malesuada ornare tortor. Proin id fermentum justo, sed
 condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
 at egestas.
-          </textarea>
-          <a href="https://commonmark.org/help/">
-            Styling with Markdown is supported.
-          </a>
+            </textarea>
+            <a href="https://commonmark.org/help/">
+              Styling with Markdown is supported.
+            </a>
+          </details>
         </section>
         <section class="project-description">
-          <h2 class="project-description-visibility">Internal</h2>
-          <textarea
-            class="project-input-description"
-            name="internalDescription"
-            placeholder="Internal project description, visible to your peers"
-            data-th-text="*{internalDescription}"
+          <details
+            data-th-open="*{!#strings.isEmpty(internalDescription)}"
           >
+            <summary>
+              <h2 class="project-description-visibility">Internal</h2>
+            </summary>
+            <textarea
+              class="project-input-description"
+              name="internalDescription"
+              placeholder="Internal project description, visible to your peers"
+              data-th-text="*{internalDescription}"
+            >
 Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
 euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
 dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
@@ -72,29 +83,36 @@ amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
 orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
 tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
 lacinia neque.
-          </textarea>
-          <a href="https://commonmark.org/help/">
-            Styling with Markdown is supported.
-          </a>
+            </textarea>
+            <a href="https://commonmark.org/help/">
+              Styling with Markdown is supported.
+            </a>
+          </details>
         </section>
         <section class="project-description">
-          <h2 class="project-description-visibility">Private</h2>
-          <textarea
-            class="project-input-description"
-            name="privateDescription"
-            placeholder="Private project description, visible only to you"
-            data-th-text="*{privateDescription}"
+          <details
+            data-th-open="*{!#strings.isEmpty(privateDescription)}"
           >
+            <summary>
+              <h2 class="project-description-visibility">Private</h2>
+            </summary>
+            <textarea
+              class="project-input-description"
+              name="privateDescription"
+              placeholder="Private project description, visible only to you"
+              data-th-text="*{privateDescription}"
+            >
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
 justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
 Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
 quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
 non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
 Cras ultrices rutrum tristique.
-          </textarea>
-          <a href="https://commonmark.org/help/">
-            Styling with Markdown is supported.
-          </a>
+            </textarea>
+            <a href="https://commonmark.org/help/">
+              Styling with Markdown is supported.
+            </a>
+          </details>
         </section>
       </section>
       <section

--- a/src/main/resources/templates/projects/new.html
+++ b/src/main/resources/templates/projects/new.html
@@ -33,19 +33,25 @@
       </section>
       <section class="project-descriptions">
         <section class="project-description">
-          <h2 class="project-description-visibility">Private</h2>
+          <h2 class="project-description-visibility">Public</h2>
           <textarea
             class="project-input-description"
-            name="privateDescription"
-            placeholder="Private project description, visible only to you"
-            data-th-text="*{privateDescription}"
+            name="publicDescription"
+            data-th-text="*{publicDescription}"
           >
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
-justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
-Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
-quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
-non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
-Cras ultrices rutrum tristique.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
+mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
+odio. Ut non tincidunt turpis. Aenean convallis eu sapien nec elementum.
+Fusce facilisis sapien risus, eget imperdiet nisi accumsan nec. Nam
+venenatis tellus aliquam ipsum placerat, nec finibus libero dignissim.
+Donec maximus ipsum lectus, non viverra orci iaculis a. Integer purus
+urna, malesuada eu risus volutpat, elementum fermentum elit. Proin ex
+velit, efficitur sit amet tempus sit amet, maximus id ex. Nam lacinia ut
+leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
+sem in, malesuada ornare tortor. Proin id fermentum justo, sed
+condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
+at egestas.
           </textarea>
           <a href="https://commonmark.org/help/">
             Styling with Markdown is supported.
@@ -72,25 +78,19 @@ lacinia neque.
           </a>
         </section>
         <section class="project-description">
-          <h2 class="project-description-visibility">Public</h2>
+          <h2 class="project-description-visibility">Private</h2>
           <textarea
             class="project-input-description"
-            name="publicDescription"
-            data-th-text="*{publicDescription}"
+            name="privateDescription"
+            placeholder="Private project description, visible only to you"
+            data-th-text="*{privateDescription}"
           >
-Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
-cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
-mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
-odio. Ut non tincidunt turpis. Aenean convallis eu sapien nec elementum.
-Fusce facilisis sapien risus, eget imperdiet nisi accumsan nec. Nam
-venenatis tellus aliquam ipsum placerat, nec finibus libero dignissim.
-Donec maximus ipsum lectus, non viverra orci iaculis a. Integer purus
-urna, malesuada eu risus volutpat, elementum fermentum elit. Proin ex
-velit, efficitur sit amet tempus sit amet, maximus id ex. Nam lacinia ut
-leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
-sem in, malesuada ornare tortor. Proin id fermentum justo, sed
-condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
-at egestas.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
+justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
+Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
+quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
+non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
+Cras ultrices rutrum tristique.
           </textarea>
           <a href="https://commonmark.org/help/">
             Styling with Markdown is supported.

--- a/src/main/resources/templates/projects/new.html
+++ b/src/main/resources/templates/projects/new.html
@@ -33,12 +33,15 @@
       </section>
       <section class="project-descriptions">
         <section class="project-description">
-          <h2 class="project-description-visibility">Public</h2>
-          <textarea
-            class="project-input-description"
-            name="publicDescription"
-            data-th-text="*{publicDescription}"
-          >
+          <details open>
+            <summary>
+              <h2 class="project-description-visibility">Public</h2>
+            </summary>
+            <textarea
+              class="project-input-description"
+              name="publicDescription"
+              data-th-text="*{publicDescription}"
+            >
 Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
 cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit
 mollis diam. Ut egestas lacus faucibus, facilisis eros vitae, pharetra
@@ -52,19 +55,23 @@ leo at dignissim. Donec vitae facilisis magna. Cras ipsum nibh, porta eu
 sem in, malesuada ornare tortor. Proin id fermentum justo, sed
 condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
 at egestas.
-          </textarea>
-          <a href="https://commonmark.org/help/">
-            Styling with Markdown is supported.
-          </a>
+            </textarea>
+            <a href="https://commonmark.org/help/">
+              Styling with Markdown is supported.
+            </a>
+          </details>
         </section>
         <section class="project-description">
-          <h2 class="project-description-visibility">Internal</h2>
-          <textarea
-            class="project-input-description"
-            name="internalDescription"
-            placeholder="Internal project description, visible to your peers"
-            data-th-text="*{internalDescription}"
-          >
+          <details>
+            <summary>
+              <h2 class="project-description-visibility">Internal</h2>
+            </summary>
+            <textarea
+              class="project-input-description"
+              name="internalDescription"
+              placeholder="Internal project description, visible to your peers"
+              data-th-text="*{internalDescription}"
+            >
 Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
 euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
 dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
@@ -72,29 +79,34 @@ amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
 orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
 tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
 lacinia neque.
-          </textarea>
-          <a href="https://commonmark.org/help/">
-            Styling with Markdown is supported.
-          </a>
+            </textarea>
+            <a href="https://commonmark.org/help/">
+              Styling with Markdown is supported.
+            </a>
+          </details>
         </section>
         <section class="project-description">
-          <h2 class="project-description-visibility">Private</h2>
-          <textarea
-            class="project-input-description"
-            name="privateDescription"
-            placeholder="Private project description, visible only to you"
-            data-th-text="*{privateDescription}"
-          >
+          <details>
+            <summary>
+              <h2 class="project-description-visibility">Private</h2>
+            </summary>
+            <textarea
+              class="project-input-description"
+              name="privateDescription"
+              placeholder="Private project description, visible only to you"
+              data-th-text="*{privateDescription}"
+            >
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a
 justo et ipsum gravida cursus. Proin aliquet in libero id tempor.
 Pellentesque suscipit placerat egestas. Phasellus facilisis nibh leo,
 quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
 non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
 Cras ultrices rutrum tristique.
-          </textarea>
-          <a href="https://commonmark.org/help/">
-            Styling with Markdown is supported.
-          </a>
+            </textarea>
+            <a href="https://commonmark.org/help/">
+              Styling with Markdown is supported.
+            </a>
+          </details>
         </section>
       </section>
       <section

--- a/src/main/resources/templates/projects/peer.html
+++ b/src/main/resources/templates/projects/peer.html
@@ -15,7 +15,10 @@
   <section data-th-replace="~{projects/common :: authorsList(${authors})}">
     <a href="common.html">Authors list fragment</a>
   </section>
-  <section class="project-descriptions">
+  <section
+    class="project-description"
+    data-th-unless="${#strings.isEmpty(project.publicDescription)}"
+  >
     <section class="project-description">
       <h2 class="project-description-visibility">Public</h2>
       <div data-th-utext="${project.publicDescription}">
@@ -34,7 +37,10 @@
         at egestas.
       </div>
     </section>
-    <section class="project-description">
+    <section
+      class="project-description"
+      data-th-unless="${#strings.isEmpty(project.internalDescription)}"
+    >
       <h2 class="project-description-visibility">Internal</h2>
       <div data-th-utext="${project.internalDescription}">
         Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,

--- a/src/main/resources/templates/projects/peer.html
+++ b/src/main/resources/templates/projects/peer.html
@@ -17,18 +17,6 @@
   </section>
   <section class="project-descriptions">
     <section class="project-description">
-      <h2 class="project-description-visibility">Internal</h2>
-      <div data-th-utext="${project.internalDescription}">
-        Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
-        euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
-        dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
-        amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
-        orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
-        tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
-        lacinia neque.
-      </div>
-    </section>
-    <section class="project-description">
       <h2 class="project-description-visibility">Public</h2>
       <div data-th-utext="${project.publicDescription}">
         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
@@ -44,6 +32,18 @@
         sem in, malesuada ornare tortor. Proin id fermentum justo, sed
         condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
         at egestas.
+      </div>
+    </section>
+    <section class="project-description">
+      <h2 class="project-description-visibility">Internal</h2>
+      <div data-th-utext="${project.internalDescription}">
+        Nulla vel tellus sit amet sem ullamcorper suscipit. Duis mi elit,
+        euismod a urna ut, semper maximus tellus. Phasellus mollis volutpat
+        dictum. Suspendisse potenti. Nam eu lectus ac quam mollis dictum sit
+        amet finibus diam. Cras eget mauris semper, interdum nulla eu, bibendum
+        orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
+        tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
+        lacinia neque.
       </div>
     </section>
   </section>

--- a/src/main/resources/templates/projects/public.html
+++ b/src/main/resources/templates/projects/public.html
@@ -16,7 +16,10 @@
     <a href="common.html">Authors list fragment</a>
   </section>
   <section class="project-descriptions">
-    <section class="project-description">
+    <section
+      class="project-description"
+      data-th-unless="${#strings.isEmpty(project.publicDescription)}"
+    >
       <div data-th-utext="${project.publicDescription}">
         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
         cubilia Curae; Fusce orci eros, feugiat eu ipsum blandit, suscipit


### PR DESCRIPTION
Redesign the descriptions on the project pages to be more vertical and to emphasize the public description over the internal and private description.

Viewing an existing project (as the author):
![layout-author](https://user-images.githubusercontent.com/1494855/57405310-1f014000-71ac-11e9-898d-59e90e050221.png)

Creating a new project:
![layout-new](https://user-images.githubusercontent.com/1494855/57405350-3809f100-71ac-11e9-95a2-744755c650db.png)

Editing an existing project:
![layout-edit](https://user-images.githubusercontent.com/1494855/57405258-f8dba000-71ab-11e9-82a1-9f28fadb3142.png)


Resolves #45 De-emphasize private project description