### PR TITLE
Fix exception when new project contains errors

### DIFF
--- a/src/main/java/com/recurse/portfolio/web/ProjectController.java
+++ b/src/main/java/com/recurse/portfolio/web/ProjectController.java
@@ -62,7 +62,8 @@ public class ProjectController {
         }
         if (bindingResult.hasErrors()) {
             return new ModelAndView("projects/new")
-                .addObject("authors", Set.of(currentUser))
+                .addObject("authors", Set.of(
+                    DisplayAuthor.fromUserForUser(currentUser, currentUser)))
                 .addObject("project", postedProject);
         } else {
             Project newProject = new Project();


### PR DESCRIPTION
When rejecting a project for containing one or more validation errors, populate the authors list with `DisplayAuthor`s instead of `User`s, to fix this error:

> [THYMELEAF][http-nio-8080-exec-1] Exception processing template "projects/new": Exception evaluating SpringEL expression:  "author.imageUrl" (template: "projects/common" - line 23, col 11)

In general, this should not happen, as the browser should prevent form submission until all the `required` fields are filled in. However, if it does, we should handle it gracefully!