### PR TITLE
Set OAuth2 callback URL via environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,5 @@
 # OAuth configuration
+export CALLBACK_HOST=http://127.0.0.1:8080
 export CLIENT_ID=your_client_id
 export CLIENT_SECRET=your_client_secret
 

--- a/README.markdown
+++ b/README.markdown
@@ -126,7 +126,8 @@ Configure your Heroku app with the credentials:
 
 ```sh
 $ heroku config:set \
-    ACCESS_TOKEN=your_access_token
+    ACCESS_TOKEN=your_access_token \
+    CALLBACK_HOST=https://example.com \
     CLIENT_ID=your_client_id \
     CLIENT_SECRET=your_client_secret
 ```

--- a/src/main/java/com/recurse/portfolio/Application.java
+++ b/src/main/java/com/recurse/portfolio/Application.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 @SpringBootApplication
 public class Application {
     private static final List<String> REQUIRED_ENVIRONMENT_VARIABLES = List.of(
+        "CALLBACK_HOST",
         "CLIENT_ID",
         "CLIENT_SECRET",
         "ACCESS_TOKEN",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring.security.oauth2.client:
       client-secret: ${CLIENT_SECRET}
       client-name: Recurse Center
       authorization-grant-type: authorization_code
-      redirect-uri-template: "{baseUrl}/login/oauth2/code/{registrationId}"
+      redirect-uri-template: "${CALLBACK_HOST}/login/oauth2/code/{registrationId}"
   provider:
     recurse:
       authorization-uri: https://www.recurse.com/oauth/authorize


### PR DESCRIPTION
Set up the application to run behind the [Recurse Center proxy](https://github.com/recursecenter/proxy) by explicitly setting the callback URL as an environment variable.