### PR TITLE
open markdown help links in new tab

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -15,7 +15,9 @@ Alphabetically by first name:
 
 - [Alan Chu](https://github.com/thechutrain)
 - [Byung Joo Shin](https://github.com/byshiny)
+- [Elana Liskovich](https://github.com/EL246)
 - [Jason Owen](https://jasonaowen.net/)
+- [Jeanine Peters](https://github.com/j9peters)
 - [Jeff Ross](https://github.com/jeffro94)
 - [Ian Ross](https://github.com/ihross)
 - [Nick Aversano](https://github.com/nickav)

--- a/src/main/resources/templates/projects/edit.html
+++ b/src/main/resources/templates/projects/edit.html
@@ -64,7 +64,7 @@ sem in, malesuada ornare tortor. Proin id fermentum justo, sed
 condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
 at egestas.
             </textarea>
-            <a href="https://commonmark.org/help/">
+            <a href="https://commonmark.org/help/" target="_blank">
               Styling with Markdown is supported.
             </a>
           </details>
@@ -95,7 +95,7 @@ orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
 tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
 lacinia neque.
             </textarea>
-            <a href="https://commonmark.org/help/">
+            <a href="https://commonmark.org/help/" target="_blank">
               Styling with Markdown is supported.
             </a>
           </details>
@@ -124,7 +124,7 @@ quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
 non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
 Cras ultrices rutrum tristique.
             </textarea>
-            <a href="https://commonmark.org/help/">
+            <a href="https://commonmark.org/help/" target="_blank">
               Styling with Markdown is supported.
             </a>
           </details>

--- a/src/main/resources/templates/projects/new.html
+++ b/src/main/resources/templates/projects/new.html
@@ -62,7 +62,7 @@ sem in, malesuada ornare tortor. Proin id fermentum justo, sed
 condimentum orci. Phasellus ac scelerisque elit. Aenean bibendum ut erat
 at egestas.
             </textarea>
-            <a href="https://commonmark.org/help/">
+            <a href="https://commonmark.org/help/" target="_blank">
               Styling with Markdown is supported.
             </a>
           </details>
@@ -92,7 +92,7 @@ orci. Quisque ut euismod elit. Quisque convallis enim nulla, et feugiat
 tortor tempus vel. Morbi diam augue, pulvinar at quam sit amet, gravida
 lacinia neque.
             </textarea>
-            <a href="https://commonmark.org/help/">
+            <a href="https://commonmark.org/help/" target="_blank">
               Styling with Markdown is supported.
             </a>
           </details>
@@ -120,7 +120,7 @@ quis pretium odio gravida id. Morbi nibh diam, elementum posuere enim
 non, vestibulum accumsan nunc. Curabitur scelerisque pulvinar varius.
 Cras ultrices rutrum tristique.
             </textarea>
-            <a href="https://commonmark.org/help/">
+            <a href="https://commonmark.org/help/" target="_blank">
               Styling with Markdown is supported.
             </a>
           </details>

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -55,7 +55,7 @@ velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
 occaecat cupidatat non proident, sunt in culpa qui officia deserunt
 mollit anim id est laborum.
           </textarea>
-          <a href="https://commonmark.org/help/">
+          <a href="https://commonmark.org/help/" target="_blank">
             Styling with Markdown is supported.
           </a>
         </label>
@@ -105,7 +105,7 @@ dolor. Maecenas condimentum magna sit amet venenatis sodales.
 Pellentesque in pulvinar orci. Nulla facilisi. Vivamus justo lorem,
 pretium sit amet pulvinar non, mattis eu metus.
           </textarea>
-          <a href="https://commonmark.org/help/">
+          <a href="https://commonmark.org/help/" target="_blank">
             Styling with Markdown is supported.
           </a>
         </label>


### PR DESCRIPTION
add target attributes to make sure markdown links open in a new tab

resolve #87 Open Markdown help links in new window

Co-authored-by: j9peters <29951738+j9peters@users.noreply.github.com>