### PR TITLE
Add header debugging endpoint

### DIFF
--- a/src/main/java/com/recurse/portfolio/web/DebuggingController.java
+++ b/src/main/java/com/recurse/portfolio/web/DebuggingController.java
@@ -1,0 +1,28 @@
+package com.recurse.portfolio.web;
+
+import lombok.extern.java.Log;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.stream.Collectors;
+
+@Controller
+@Log
+public class DebuggingController {
+    @GetMapping("/debug/headers")
+    public ModelAndView showHeaders(
+        @RequestHeader HttpHeaders headers
+    ) {
+        log.info(headers::toString);
+        String renderedHeaders = headers.entrySet().stream()
+            .flatMap(entry -> entry.getValue().stream()
+                .map(value -> entry.getKey() + ": " + value))
+            .sorted()
+            .collect(Collectors.joining("\n"));
+        return new ModelAndView("debug/headers")
+            .addObject("headers", renderedHeaders);
+    }
+}

--- a/src/main/resources/templates/debug/headers.html
+++ b/src/main/resources/templates/debug/headers.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" data-th-replace="~{base :: layout(~{::title}, ~{::main})}">
+<head>
+  <title>Request Headers</title>
+  <link rel="stylesheet" href="../../static/style.css"/>
+</head>
+<body>
+<main class="tag">
+  <h1>Request Headers</h1>
+  <pre data-th-text=${headers}>X-Header-Example: example content</pre>
+</main>
+</body>
+</html>


### PR DESCRIPTION
In order to help figure out what's going on with the RC proxy and/or Heroku, add an endpoint that both logs and prints the request headers seen by the application.

Related to https://github.com/recursecenter/proxy/issues/5

Issue #89 Improve domain name