### PR TITLE
Configure Flyway gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,3 +34,9 @@ dependencies {
   compile('org.springframework.boot:spring-boot-starter-web')
   testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+flyway {
+  url = System.getenv('JDBC_DATABASE_URL')
+  user = System.getenv('JDBC_DATABASE_USERNAME')
+  password = System.getenv('JDBC_DATABASE_PASSWORD')
+}


### PR DESCRIPTION
Configure the [Flyway gradle plugin](https://flywaydb.org/documentation/gradle/), added in PR #8, so that the tasks it adds work as expected. This depends on the same environment variables as the application itself.