### PR TITLE
Switch web server to Undertow for proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,10 @@ dependencies {
   compile('org.springframework.boot:spring-boot-starter-oauth2-client')
   compile('org.springframework.boot:spring-boot-starter-security')
   compile('org.springframework.boot:spring-boot-starter-thymeleaf')
-  compile('org.springframework.boot:spring-boot-starter-web')
+  compile('org.springframework.boot:spring-boot-starter-undertow')
+  compile('org.springframework.boot:spring-boot-starter-web') {
+    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+  }
   testCompile('org.springframework.boot:spring-boot-starter-test')
 }
 


### PR DESCRIPTION
Use Undertow instead of the default Tomcat web server, as Tomcat does not support the `X-Forwarded-Host` header, and so cannot determine the hostname to use in constructing the OAuth2 redirect URI.

Issue #89 Improve domain name