### PR TITLE
More readable URL's and private profile name visibility fix

### DIFF
--- a/src/main/java/com/recurse/portfolio/data/DisplayAuthor.java
+++ b/src/main/java/com/recurse/portfolio/data/DisplayAuthor.java
@@ -15,7 +15,7 @@ public class DisplayAuthor {
     ) {
         switch(sourceUser.getProfileVisibility()) {
             case PRIVATE:
-                if (sourceUser == requestingUser) {
+                if (sourceUser.equals(requestingUser)) {
                     return useInternal(sourceUser);
                 } else {
                     return anonymous();

--- a/src/main/java/com/recurse/portfolio/data/DisplayAuthor.java
+++ b/src/main/java/com/recurse/portfolio/data/DisplayAuthor.java
@@ -1,5 +1,6 @@
 package com.recurse.portfolio.data;
 
+import com.github.slugify.Slugify;
 import lombok.NonNull;
 import lombok.Value;
 
@@ -8,6 +9,8 @@ public class DisplayAuthor {
     int userId;
     String name;
     String imageUrl;
+    String slugifiedName;
+    static Slugify slugify = new Slugify();
 
     public static DisplayAuthor fromUserForUser(
         @NonNull User sourceUser,
@@ -41,23 +44,30 @@ public class DisplayAuthor {
         return new DisplayAuthor(
             0,
             "Anonymous",
-            "/user-placeholder.png"
+            "/user-placeholder.png",
+            null
         );
     }
 
     private static DisplayAuthor usePublic(User user) {
+        String slug = slugify.slugify(user.getPublicName());
+
         return new DisplayAuthor(
             user.getUserId(),
             user.getPublicName(),
-            user.getPublicImageUrl()
+            user.getPublicImageUrl(),
+            slug
         );
     }
 
     private static DisplayAuthor useInternal(User user) {
+        String slug = slugify.slugify(user.getInternalName());
+
         return new DisplayAuthor(
             user.getUserId(),
             user.getInternalName(),
-            user.getInternalImageUrl()
+            user.getInternalImageUrl(),
+            slug
         );
     }
 }

--- a/src/main/java/com/recurse/portfolio/data/DisplayProject.java
+++ b/src/main/java/com/recurse/portfolio/data/DisplayProject.java
@@ -4,11 +4,13 @@ import lombok.Value;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+import com.github.slugify.Slugify;
 
 @Value
 public class DisplayProject {
     int projectId;
     String name;
+    String slugifiedName;
     Set<DisplayAuthor> authors;
     Set<Tag> tags;
 
@@ -16,9 +18,14 @@ public class DisplayProject {
         Project project,
         User currentUser
     ) {
+
+        Slugify slugifier = new Slugify();
+        String slugifiedName = slugifier.slugify(project.getName());
+
         return new DisplayProject(
             project.getProjectId(),
             project.getName(),
+            slugifiedName,
             project.getAuthors().stream()
                 .map(u -> DisplayAuthor.fromUserForUser(u, currentUser))
                 .collect(Collectors.toUnmodifiableSet()),

--- a/src/main/java/com/recurse/portfolio/web/ProjectListController.java
+++ b/src/main/java/com/recurse/portfolio/web/ProjectListController.java
@@ -25,6 +25,7 @@ public class ProjectListController {
             currentUser,
             pageable
         );
+
         return new ModelAndView("projects/list")
             .addObject("projects", projects);
     }

--- a/src/main/java/com/recurse/portfolio/web/UserController.java
+++ b/src/main/java/com/recurse/portfolio/web/UserController.java
@@ -1,5 +1,6 @@
 package com.recurse.portfolio.web;
 
+import com.github.slugify.Slugify;
 import com.recurse.portfolio.data.DisplayProjectRepository;
 import com.recurse.portfolio.data.User;
 import com.recurse.portfolio.data.UserRepository;
@@ -31,10 +32,20 @@ public class UserController {
     @Autowired
     UserRepository repository;
 
-    @GetMapping("/user/{userId}")
+    @GetMapping("/user/{userId}/**")
+    public ModelAndView showUserRedirect(
+        @CurrentUser User currentUser,
+        @PathVariable Integer userId,
+        Pageable pageable
+    ) {
+        return showUser(currentUser, userId, "", pageable);
+    }
+
+    @GetMapping("/user/{userId}/{userName}")
     public ModelAndView showUser(
         @CurrentUser User currentUser,
         @PathVariable Integer userId,
+        @PathVariable String userName,
         Pageable pageable
     ) {
         User requestedUser = repository.findById(userId)
@@ -48,6 +59,24 @@ public class UserController {
         );
 
         var mv = new ModelAndView(policy.evaluate(requestedUser, currentUser));
+
+        var namePolicy = new VisibilityPolicy<>(
+                requestedUser.getProfileVisibility(),
+                requestedUser.getInternalName(),
+                requestedUser.getInternalName(),
+                requestedUser.getPublicName()
+        );
+
+        String name = namePolicy.evaluate(requestedUser, currentUser);
+
+        Slugify slugifier = new Slugify();
+        String slugifiedName = slugifier.slugify(name);
+
+        if (!slugifiedName.equals(userName)) {
+            return new ModelAndView(new RedirectView(
+                    "/user/" + userId + "/" + slugifiedName
+            ));
+        }
 
         requestedUser.setPublicBio(renderMarkdownToHtml(
             requestedUser.getPublicBio()
@@ -67,7 +96,7 @@ public class UserController {
             );
     }
 
-    @GetMapping("/user/{userId}/edit")
+    @GetMapping("/user/edit/{userId}")
     public ModelAndView getEditMyProfile(
         @CurrentUser User currentUser,
         @PathVariable Integer userId
@@ -86,7 +115,7 @@ public class UserController {
             .addObject("user", requestedUser);
     }
 
-    @PostMapping("/user/{id}/edit")
+    @PostMapping("/user/edit/{id}")
     public ModelAndView postEditMyProfile(
         @CurrentUser User currentUser,
         @PathVariable(name = "id") Integer userId,

--- a/src/main/resources/templates/projects/list.html
+++ b/src/main/resources/templates/projects/list.html
@@ -19,7 +19,7 @@
                   data-th-each="author : ${project.authors}"
                   class="badge-image-container"
                 >
-                  <a data-th-href="@{/user/{id}(id=${author.userId})}">
+                  <a data-th-href="@{/user/{id}/{slug}(id=${author.userId}, slug=${author.slugifiedName})}">
                     <img
                       class="badge-image"
                       src="../../static/user-placeholder.png"
@@ -31,7 +31,7 @@
                 <div class="description-project-name">
                   <a
                     href="projects/public.html"
-                    data-th-href="@{/project/{id}(id=${project.projectId})}"
+                    data-th-href="@{/project/{id}/{slug}(id=${project.projectId},slug=${project.slugifiedName})}"
                     data-th-text="${project.name}"
                     >Project Name</a
                   >
@@ -46,7 +46,7 @@
                         <a
                           class="global-project-list-item-author"
                           href="users/public.html"
-                          data-th-href="@{/user/{id}(id=${author.userId})}"
+                          data-th-href="@{/user/{id}/{slug}(id=${author.userId}, slug=${author.slugifiedName})}"
                           data-th-text="${author.name}"
                           >Author Name</a
                         ><span

--- a/src/main/resources/templates/users/edit.html
+++ b/src/main/resources/templates/users/edit.html
@@ -8,7 +8,7 @@
 <main>
   <form
     data-th-object="${user}"
-    data-th-action="@{/user/{id}/edit(id=${user.userId})}"
+    data-th-action="@{/user/edit/{id}(id=${user.userId})}"
     method="post"
   >
     <section class="user-details">

--- a/src/main/resources/templates/users/self.html
+++ b/src/main/resources/templates/users/self.html
@@ -79,7 +79,7 @@
     <div>
       <a
         href="edit.html"
-        data-th-href="@{/user/{id}/edit(id=${user.userId})}"
+        data-th-href="@{/user/edit/{id}(id=${user.userId})}"
       >Edit</a>
     </div>
   </section>


### PR DESCRIPTION
Include slugified user name in user URL's
Links to projects in project lists now contain project slugs
A user with private profile visibility can now view their own name in project listings when they are logged in

Issue #12 More readable URLs
Resolves issue #97 Authors shown as "Anonymous" on the project list page when full author name should be visible

Co-authored-by: EL246 25569192+EL246@users.noreply.github.com