### PR TITLE
Upgrade to Gradle 5.6.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade to the latest version of the Gradle build tool, version 5.6.2. From the [release notes](https://docs.gradle.org/5.6.2/release-notes.html) and the [upgrade guide](https://docs.gradle.org/5.6.2/userguide/upgrading_version_5.html), there doesn't seem to be any relevant breaking changes, and I was able to successfully build, test, and run the application locally.