### PR TITLE
Run Flyway migrations at release time, not on boot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   postgresql: "10"
 before_script:
   - createdb -U postgres portfolio
+  - ./gradlew flywayMigrate
 env:
   global:
     - CLIENT_ID=_

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: ./gradlew flywayMigrate
 web: java -Dserver.port=$PORT $JAVA_OPTS -jar build/libs/*.jar

--- a/README.markdown
+++ b/README.markdown
@@ -85,6 +85,13 @@ and then
 Put the database URL and credentials in the `JDBC_DATABASE` variables
 in your `.env` file.
 
+Run the database migrations to create the database structure:
+
+```
+$ source .env
+$ ./gradlew flywayMigrate
+```
+
 Populate the database
 by running the API sync:
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
   compile('com.github.slugify:slugify:2.3')
   compile('com.vladsch.flexmark:flexmark-all:0.42.6')
   compile('com.zaxxer:HikariCP:3.3.1')
-  compile('org.flywaydb:flyway-core:5.2.4')
   compile('org.jsoup:jsoup:1.11.3')
   compile('org.postgresql:postgresql:42.2.5')
   compile('org.springframework.boot:spring-boot-starter-data-jdbc')


### PR DESCRIPTION
There have been a few Heroku [H20 App boot timeout errors](https://devcenter.heroku.com/articles/error-codes#h20-app-boot-timeout) recently, which means the application took longer than 75 seconds to start up.

Running Flyway migrations at boot time is the recommended approach, and is supported by Spring Boot: migrations are run at application start up when `flyway-core` is added as a dependency ([Flyway docs](https://flywaydb.org/documentation/plugins/springboot), [Spring Boot docs](https://docs.spring.io/spring-boot/docs/2.1.3.RELEASE/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup)). However, that recommendation appears to be written in the context of long-lived deployments, where application start up time is not considered important.

Instead, Heroku [recommends](https://devcenter.heroku.com/articles/running-database-migrations-for-java-apps#using-flyway) running database migrations during the [release phase](https://devcenter.heroku.com/articles/release-phase). This ensures that the migrations are run before any code that depends on them is run, as every code change causes a deployment and every deployment runs the release phase, without imposing the start up time cost.

This does have a drawback: creating new migrations in development now requires manually running the migration, rather than just starting the application. This can lead to running the application without the new migration applied, which is an error that was not previously possible.