### PR TITLE
Upgrade Flyway to version 6.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'java'
   id 'idea'
   id 'org.springframework.boot' version '2.1.3.RELEASE'
-  id 'org.flywaydb.flyway' version '5.2.4'
+  id 'org.flywaydb.flyway' version '6.0.3'
   id 'io.spring.dependency-management' version '1.0.7.RELEASE'
   id 'io.freefair.lombok' version '3.2.0'
   id 'com.adarshr.test-logger' version '1.6.0'


### PR DESCRIPTION
Upgrade to the latest version of the Flyway database migration tool, which notably includes support for PostgreSQL 11. We're not doing anything fancy, and PostgreSQL's backwards compatibility is great, but this will suppress warning messages like this:

> Flyway upgrade recommended: PostgreSQL 11.5 is newer than this version of Flyway and support has not been tested.

Release notes:
- https://flywaydb.org/blog/flyway-6.0.0
- https://flywaydb.org/blog/flyway-6.0.1
- https://flywaydb.org/blog/flyway-6.0.2
- https://flywaydb.org/blog/flyway-6.0.3