### PR TITLE
Upgrade slugify from 2.3 to 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = 11
 targetCompatibility = 11
 
 dependencies {
-  compile('com.github.slugify:slugify:2.3')
+  compile('com.github.slugify:slugify:2.4')
   compile('com.vladsch.flexmark:flexmark-all:0.42.6')
   compile('com.zaxxer:HikariCP:3.3.1')
   compile('org.jsoup:jsoup:1.11.3')


### PR DESCRIPTION
The slugify library released [version 2.4](https://github.com/slugify/slugify/releases/tag/slugify-parent-2.4), which in turn [updates its dependency on ICU](https://github.com/slugify/slugify/compare/slugify-parent-2.3...slugify-parent-2.4).